### PR TITLE
Set style and font

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -19,6 +19,14 @@ const config: GatsbyConfig = {
     "gatsby-plugin-image",
     "gatsby-plugin-sharp",
     "gatsby-transformer-sharp",
+    {
+      resolve: "gatsby-plugin-web-font-loader",
+      options: {
+        google: {
+          families: ["Nunito"]
+        }
+      }
+    }
   ],
 }
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gatsby": "^5.0.0",
     "gatsby-plugin-image": "^3.3.2",
     "gatsby-plugin-sharp": "^5.0.0",
+    "gatsby-plugin-web-font-loader": "^1.0.4",
     "gatsby-source-filesystem": "^5.0.0",
     "gatsby-source-sanity": "^7.6.1",
     "gatsby-transformer-sharp": "^5.0.0",

--- a/src/components/App/theme.ts
+++ b/src/components/App/theme.ts
@@ -33,9 +33,31 @@ const theme = createTheme({
   },
   typography: {
     fontFamily: '"Nunito", -apple-system, sans-serif',
+    h1: {
+      fontWeight: 700,
+    },
+    h2: {
+      fontWeight: 700,
+    },
+    h3: {
+      fontWeight: 700,
+    },
+    h4: {
+      fontWeight: 700,
+    },
+    h5: {
+      fontWeight: 700
+    },
+    h6: {
+      fontWeight: 700,
+    },
     subtitle1: bodyFontFamily,
     body1: bodyFontFamily,
-    body2: bodyFontFamily
+    body2: bodyFontFamily,
+    button: {
+      textTransform: "capitalize",
+      fontWeight: 700,
+    }
   }
 })
 

--- a/src/components/App/theme.ts
+++ b/src/components/App/theme.ts
@@ -18,6 +18,9 @@ const PINK: PaletteColorOptions = {
   dark: '#DA0758',
 }
 
+const bodyFontFamily = {
+  fontFamily: "Arial, sans-serif",
+}
 
 const theme = createTheme({
   palette: {
@@ -27,6 +30,12 @@ const theme = createTheme({
   },
   shape: {
     borderRadius: 4
+  },
+  typography: {
+    fontFamily: '"Nunito", -apple-system, sans-serif',
+    subtitle1: bodyFontFamily,
+    body1: bodyFontFamily,
+    body2: bodyFontFamily
   }
 })
 

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -125,12 +125,12 @@ export default function Header() {
             >
               <List>
                 {PAGES.map((page) => (
-                  <>
-                  <ListItem key={page.text}>
-                    <ListItemText>{page.text}</ListItemText>
-                  </ListItem>
+                  <React.Fragment key={page.text}>
+                    <ListItem key={page.text}>
+                      <ListItemText>{page.text}</ListItemText>
+                    </ListItem>
                     {page.subPages ? (
-                      <List sx={{pl: 4}} disablePadding>
+                      <List sx={{ pl: 4 }} disablePadding>
                         {page.subPages.map((subPage) => (
                           <ListItemButton
                             key={subPage.text}
@@ -143,7 +143,7 @@ export default function Header() {
                     ) : (
                       <></>
                     )}
-                    </>
+                  </React.Fragment>
                 ))}
               </List>
             </SwipeableDrawer>

--- a/src/components/Header/HeaderPageLink.tsx
+++ b/src/components/Header/HeaderPageLink.tsx
@@ -45,7 +45,7 @@ export default function HeaderPageLink({ page }: HeaderPageLinkProps) {
         color="inherit"
         endIcon={subPages ? <ExpandMoreIcon /> : <></>}
       >
-        {text}
+        <b>{text}</b>
       </LinkButton>
       {subPages ? (
         <Menu

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -200,7 +200,7 @@ export default function IndexPage({ data }: PageProps<Queries.IndexPageQuery>) {
       {/* Whole Person Leadership */}
       <Section>
         <Grid container justifyContent="space-between">
-          <Grid xs={12} lg={6} sx={{
+          <Grid xs={12} lg={5} sx={{
             display: { xs: "none", lg: "block"}
           }}>
             {/* <Placeholder /> */}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { Box, Stack, Typography, styled } from "@mui/material"
+import { Box, Container, Stack, Typography } from "@mui/material"
 import Grid from "@mui/material/Unstable_Grid2"
 import { Favorite, AutoAwesome, RocketLaunch } from "@mui/icons-material"
 import { graphql, PageProps } from "gatsby"
@@ -93,7 +93,7 @@ export default function IndexPage({ data }: PageProps<Queries.IndexPageQuery>) {
           {/* Header */}
           <Grid xs={12} md={6}>
             <Typography
-              variant="h1"
+              variant="h2"
               textAlign={{
                 xs: "center",
                 md: "left",
@@ -144,11 +144,14 @@ export default function IndexPage({ data }: PageProps<Queries.IndexPageQuery>) {
           display: { xs: "none", md: "block" },
         }}
       >
-        <Stack spacing={4}>
+        <Stack spacing={4} alignItems="center">
           <Typography variant="h3" textAlign="center">
             {sanityHomePage.aboutHeader}
           </Typography>
+          <Container maxWidth="sm" sx={{textAlign: "center"}}>
           <PortableText content={sanityHomePage._rawAboutBody} />
+          </Container>
+
         </Stack>
       </Section>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3146,6 +3146,14 @@ babel-preset-gatsby@^3.3.1:
     gatsby-core-utils "^4.3.1"
     gatsby-legacy-polyfills "^3.3.0"
 
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  integrity sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
+
 backo2@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
@@ -3814,6 +3822,11 @@ core-js-pure@^3.23.3, core-js-pure@^3.25.1:
   version "3.27.1"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.27.1.tgz#ede4a6b8440585c7190062757069c01d37a19dca"
   integrity sha512-BS2NHgwwUppfeoqOXqi08mUqS5FiZpuRuJJpKsaME7kJz0xxuk0xkhDdfMIlP/zLa80krBqss1LtD7f889heAw==
+
+core-js@^2.4.0:
+  version "2.6.12"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
+  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-js@^3.22.3:
   version "3.27.1"
@@ -5437,6 +5450,14 @@ gatsby-plugin-utils@^4.1.0, gatsby-plugin-utils@^4.3.1:
     import-from "^4.0.0"
     joi "^17.7.0"
     mime "^3.0.0"
+
+gatsby-plugin-web-font-loader@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-web-font-loader/-/gatsby-plugin-web-font-loader-1.0.4.tgz#c50bdb0c1980110b3fd213a5be70feb2459514c3"
+  integrity sha512-3c39bX9CcsYJQFhhmTyjuMJSqpld2rX+HsTOxP9k1PKFR4Rvo3lpzBW4d1tVpmUesR8BNL6u9eHT7/XksS1iog==
+  dependencies:
+    babel-runtime "^6.26.0"
+    webfontloader "^1.6.28"
 
 gatsby-react-router-scroll@^6.3.0:
   version "6.3.0"
@@ -8350,6 +8371,11 @@ regenerate@^1.4.2:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
+regenerator-runtime@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
+
 regenerator-runtime@^0.13.11, regenerator-runtime@^0.13.7:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
@@ -9644,6 +9670,11 @@ weak-lru-cache@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz#fdbb6741f36bae9540d12f480ce8254060dccd19"
   integrity sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==
+
+webfontloader@^1.6.28:
+  version "1.6.28"
+  resolved "https://registry.yarnpkg.com/webfontloader/-/webfontloader-1.6.28.tgz#db786129253cb6e8eae54c2fb05f870af6675bae"
+  integrity sha512-Egb0oFEga6f+nSgasH3E0M405Pzn6y3/9tOVanv/DLfa1YBIgcv90L18YyWnvXkRbIM17v5Kv6IT2N6g1x5tvQ==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
Adds the gatsby-plugin-web-font-loader plugin which allows us to import Google fonts. We import the Nunito font to use as the header font family

Also fixes various sizing and font weight issues from switching to a different font

Button now are Title Case rather than UPPERCASE