### PR TITLE
Add cookbook page + cookbook page components

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "gatsby-source-sanity": "^7.6.1",
     "gatsby-transformer-sharp": "^5.0.0",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "react-spring": "^9.7.1",
+    "react-spring-carousel": "^2.0.19"
   },
   "devDependencies": {
     "@types/node": "^18.11.9",

--- a/src/components/Button/AnimatedIconButton.tsx
+++ b/src/components/Button/AnimatedIconButton.tsx
@@ -1,16 +1,16 @@
 import React from "react"
 import { animated } from "@react-spring/web"
-import { Button, ButtonProps } from "@mui/material"
+import { IconButton, ButtonProps } from "@mui/material"
 
 import useBoop, { BoopProps } from "@hooks/useBoop"
 
-const SpringAnimatedButton = animated(Button)
+const SpringAnimatedButton = animated(IconButton)
 
 type Props = ButtonProps & {
   boopProps: BoopProps
 }
 
-export default function AnimatedButton({
+export default function AnimatedIconButton({
   boopProps,
   disabled,
   ...rest

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -1,3 +1,4 @@
 export { default as AnimatedButton } from "./AnimatedButton"
+export { default as AnimatedIconButton } from "./AnimatedIconButton"
 export { default as LinkButton } from "./LinkButton"
 export { default as SanityButton } from "./SanityButton"

--- a/src/components/Image/index.ts
+++ b/src/components/Image/index.ts
@@ -1,0 +1,3 @@
+export { default as SanityImage} from "./SanityImage"
+
+export type {sanityImageFragment} from "./SanityImage"

--- a/src/components/Product/Dropdown.tsx
+++ b/src/components/Product/Dropdown.tsx
@@ -1,0 +1,45 @@
+import React from "react"
+import { graphql } from "gatsby"
+import {
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Typography,
+} from "@mui/material"
+import { ExpandMore } from "@mui/icons-material"
+
+import PortableText from "@components/PortableText"
+
+export const sanityDropdownFragment = graphql`
+  fragment SanityDropdown on SanityDropdown {
+    _key
+    dropdownHeader
+    _rawDropdownBody
+  }
+`
+
+type DropdownProps = {
+  content: Queries.SanityDropdownFragment | null | undefined
+}
+
+export default function Dropdown({ content }: DropdownProps) {
+  if (!content) {
+    return <></>
+  }
+
+  const { dropdownHeader, _rawDropdownBody } = content
+  return (
+    <Accordion key={`additional-details-${dropdownHeader}`} elevation={0}>
+      <AccordionSummary
+        expandIcon={<ExpandMore />}
+        aria-controls={`${dropdownHeader}-content`}
+        id={`${dropdownHeader}-`}
+      >
+        <Typography>{dropdownHeader}</Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        <PortableText content={_rawDropdownBody} />
+      </AccordionDetails>
+    </Accordion>
+  )
+}

--- a/src/components/Product/Dropdown.tsx
+++ b/src/components/Product/Dropdown.tsx
@@ -35,7 +35,7 @@ export default function Dropdown({ content }: DropdownProps) {
         aria-controls={`${dropdownHeader}-content`}
         id={`${dropdownHeader}-`}
       >
-        <Typography>{dropdownHeader}</Typography>
+        <Typography variant="h6" color="gray">{dropdownHeader}</Typography>
       </AccordionSummary>
       <AccordionDetails>
         <PortableText content={_rawDropdownBody} />

--- a/src/components/Product/Dropdown.tsx
+++ b/src/components/Product/Dropdown.tsx
@@ -8,6 +8,7 @@ import {
 } from "@mui/material"
 import { ExpandMore } from "@mui/icons-material"
 
+import { SanityType } from "@utils/typeUtils"
 import PortableText from "@components/PortableText"
 
 export const sanityDropdownFragment = graphql`
@@ -19,7 +20,7 @@ export const sanityDropdownFragment = graphql`
 `
 
 type DropdownProps = {
-  content: Queries.SanityDropdownFragment | null | undefined
+  content: SanityType<Queries.SanityDropdownFragment>
 }
 
 export default function Dropdown({ content }: DropdownProps) {

--- a/src/components/Product/ImageCarousel.tsx
+++ b/src/components/Product/ImageCarousel.tsx
@@ -1,0 +1,43 @@
+import React from "react"
+import Grid from "@mui/material/Unstable_Grid2/Grid2"
+
+import { SanityImage } from "@components/Image"
+
+type ImageCarouselProps = {
+  images:
+    | readonly (Queries.SanityImageAssetFragment | null | undefined)[]
+    | null
+    | undefined
+}
+
+export default function ImageCarousel({ images }: ImageCarouselProps) {
+  if (!images || images.length <= 0) {
+    return <></>
+  }
+
+  const [index, setIndex] = React.useState(0)
+  const displayedImages = images.slice(0, 5)
+  const numRemainingImages = Math.max(0, images.length - displayedImages.length)
+
+  return (
+    // TODO: Add full-screen viewer
+    <Grid container justifyContent="center" alignItems="stretch" spacing={1}>
+      <Grid xs={12}>
+        <SanityImage imageAsset={images[index]} hasRoundedCorners />
+      </Grid>
+      {displayedImages.map((imageAsset, i) => (
+        <Grid xs={2} key={`image-carousel-${i}`}>
+          <SanityImage imageAsset={imageAsset} hasRoundedCorners />
+        </Grid>
+      ))}
+      {numRemainingImages > 0 ? (
+        <Grid xs={2}>
+          {/* TODO: Add overlay */}
+          <SanityImage imageAsset={images[displayedImages.length]} hasRoundedCorners />{" "}
+        </Grid>
+      ) : (
+        <></>
+      )}
+    </Grid>
+  )
+}

--- a/src/components/Product/ImageCarousel.tsx
+++ b/src/components/Product/ImageCarousel.tsx
@@ -1,11 +1,12 @@
 import React from "react"
 import Grid from "@mui/material/Unstable_Grid2/Grid2"
 
+import { SanityType } from "@utils/typeUtils"
 import { SanityImage } from "@components/Image"
 
 type ImageCarouselProps = {
   images:
-    | readonly (Queries.SanityImageAssetFragment | null | undefined)[]
+    | readonly SanityType<Queries.SanityImageAssetFragment>[]
     | null
     | undefined
 }

--- a/src/components/Product/index.ts
+++ b/src/components/Product/index.ts
@@ -1,0 +1,1 @@
+export {default as ImageCarousel} from "./ImageCarousel"

--- a/src/components/Product/index.ts
+++ b/src/components/Product/index.ts
@@ -1,1 +1,2 @@
+export {default as Dropdown} from "./Dropdown"
 export {default as ImageCarousel} from "./ImageCarousel"

--- a/src/components/Quotes/Quote.tsx
+++ b/src/components/Quotes/Quote.tsx
@@ -1,0 +1,61 @@
+import React from "react"
+import { graphql } from "gatsby"
+import { Card, CardContent, Stack, Typography, useTheme } from "@mui/material"
+import { FormatQuote } from "@mui/icons-material"
+import { useSpring, animated, useResize, config } from "@react-spring/web"
+import PortableText from "@components/PortableText"
+
+export const sanityQuoteFragment = graphql`
+  fragment SanityQuote on SanityQuote {
+    _key
+    name
+    _rawContent
+    yearsAttendedCamp
+  }
+`
+const AnimatedCard = animated(Card)
+
+type QuoteProps = {
+  content: Queries.SanityQuoteFragment | null | undefined
+  isSelected: boolean
+  color: "primary" | "secondary" | "tertiary"
+}
+
+export default function Quote({
+  content,
+  color,
+  isSelected,
+}: QuoteProps) {
+  const theme = useTheme()
+  const cardStyles = useSpring({
+    backgroundColor: isSelected
+      ? theme.palette[color].dark
+      : theme.palette.offwhite,
+    color: isSelected
+      ? theme.palette[color].contrastText
+      : theme.palette[color].dark,
+    opacity: isSelected ? 1 : 0.4,
+    config: config.slow,
+  })
+
+  if (!content) {
+    return <></>
+  }
+
+  const { name, _rawContent, yearsAttendedCamp } = content
+
+  return (
+    <AnimatedCard style={cardStyles}>
+      <CardContent>
+        <Stack justifyContent="space-evenly" spacing={2}>
+          <FormatQuote fontSize="large" />
+          <PortableText content={_rawContent} />
+          <Stack>
+            <Typography>{name}</Typography>
+            {yearsAttendedCamp && <Typography>{yearsAttendedCamp}</Typography>}
+          </Stack>
+        </Stack>
+      </CardContent>
+    </AnimatedCard>
+  )
+}

--- a/src/components/Quotes/QuoteCarousel.tsx
+++ b/src/components/Quotes/QuoteCarousel.tsx
@@ -1,0 +1,71 @@
+import React from "react"
+import { Stack, useTheme } from "@mui/material"
+import Grid from "@mui/material/Unstable_Grid2/Grid2"
+import { useSpringCarousel } from "react-spring-carousel"
+
+import { SanityType } from "@utils/typeUtils"
+import Quote from "./Quote"
+import { AnimatedIconButton } from "@components/Button"
+import { ChevronLeft, ChevronRight } from "@mui/icons-material"
+
+type QuoteCarousel = {
+  quotes: SanityType<readonly SanityType<Queries.SanityQuoteFragment>[]>
+}
+
+export default function QuoteCarousel({ quotes }: QuoteCarousel) {
+  const theme = useTheme()
+  const [activeIndex, setActiveIndex] = React.useState(1)
+  const numQuotes = quotes?.length || 0
+
+  const {
+    carouselFragment,
+    slideToPrevItem,
+    slideToNextItem,
+    useListenToCustomEvent,
+  } = useSpringCarousel({
+    gutter: Number(theme.spacing(2).replace("px", "")), // remove the px from the spacing string
+    itemsPerSlide: 3,
+    withLoop: true,
+    items: quotes
+      ? quotes.map((quote, index) => ({
+          id: quote?._key || `quote-${index}`,
+          renderItem: (
+            <Quote
+              content={quote}
+              isSelected={index == activeIndex}
+              color="primary"
+            />
+          ),
+        }))
+      : [],
+  })
+
+  // Update the active quote
+  useListenToCustomEvent((event) => {
+    if (event.eventName === "onSlideStartChange") {
+      setActiveIndex((event.nextItem.index + 1) % numQuotes)
+    }
+  })
+
+  return (
+    <Grid container spacing={1} justifyContent="center">
+      <Grid xs={false}>{carouselFragment}</Grid>
+      <Grid xs={1}>
+        <AnimatedIconButton
+          boopProps={{ scale: 1.1 }}
+          onClick={slideToPrevItem}
+        >
+          <ChevronLeft fontSize="large" />
+        </AnimatedIconButton>
+      </Grid>
+      <Grid xs={1}>
+        <AnimatedIconButton
+          boopProps={{ scale: 1.1 }}
+          onClick={slideToNextItem}
+        >
+          <ChevronRight fontSize="large" />
+        </AnimatedIconButton>
+      </Grid>
+    </Grid>
+  )
+}

--- a/src/components/Quotes/QuoteCarousel.tsx
+++ b/src/components/Quotes/QuoteCarousel.tsx
@@ -10,9 +10,10 @@ import { ChevronLeft, ChevronRight } from "@mui/icons-material"
 
 type QuoteCarousel = {
   quotes: SanityType<readonly SanityType<Queries.SanityQuoteFragment>[]>
+  color: "primary" | "secondary" | "tertiary"
 }
 
-export default function QuoteCarousel({ quotes }: QuoteCarousel) {
+export default function QuoteCarousel({ quotes, color }: QuoteCarousel) {
   const theme = useTheme()
   const [activeIndex, setActiveIndex] = React.useState(1)
   const numQuotes = quotes?.length || 0
@@ -33,7 +34,7 @@ export default function QuoteCarousel({ quotes }: QuoteCarousel) {
             <Quote
               content={quote}
               isSelected={index == activeIndex}
-              color="primary"
+              color={color}
             />
           ),
         }))

--- a/src/components/Quotes/QuoteCarousel.tsx
+++ b/src/components/Quotes/QuoteCarousel.tsx
@@ -50,7 +50,7 @@ export default function QuoteCarousel({ quotes, color }: QuoteCarousel) {
 
   return (
     <Grid container spacing={1} justifyContent="center">
-      <Grid xs={false}>{carouselFragment}</Grid>
+      <Grid xs={12}>{carouselFragment}</Grid>
       <Grid xs={1}>
         <AnimatedIconButton
           boopProps={{ scale: 1.1 }}

--- a/src/components/Quotes/index.ts
+++ b/src/components/Quotes/index.ts
@@ -1,0 +1,2 @@
+export { default as Quote } from "./Quote"
+export { default as QuoteCarousel } from "./QuoteCarousel"

--- a/src/pages/get-involved/cookbook.tsx
+++ b/src/pages/get-involved/cookbook.tsx
@@ -8,8 +8,32 @@ import getPageTitle from "@utils/getPageTitle"
 export const query = graphql`
   query CookbookPage {
     sanityCookbookPage {
-      mainHeader
-      subHeader
+      productReference {
+        name
+        subheader
+        edition
+        slug {
+          current
+        }
+        price
+        isDonation
+        paymentLinkButton {
+          ...SanityButton
+        }
+        _rawDescription
+        additionalDetails {
+          dropdownHeader
+          _rawDropdownBody
+        }
+        photos {
+          ...SanityImageAsset
+        }
+        quotes {
+          name
+          _rawContent
+          yearsAttendedCamp
+        }
+      }
     }
   }
 `
@@ -26,10 +50,7 @@ export default function CookbookPage({
   return (
     <>
       <Section>
-        <Stack>
-          <Typography variant="h3">{sanityCookbookPage?.mainHeader}</Typography>
-          <Typography variant="h6">{sanityCookbookPage?.subHeader}</Typography>
-        </Stack>
+        <Stack></Stack>
       </Section>
     </>
   )

--- a/src/pages/get-involved/cookbook.tsx
+++ b/src/pages/get-involved/cookbook.tsx
@@ -85,7 +85,7 @@ export default function CookbookPage({
 
           {/* Quotes */}
           <Grid xs={12}>
-            <QuoteCarousel quotes={product?.quotes} />
+            <QuoteCarousel quotes={product?.quotes} color="primary" />
           </Grid>
         </Grid>
       </Section>

--- a/src/pages/get-involved/cookbook.tsx
+++ b/src/pages/get-involved/cookbook.tsx
@@ -8,6 +8,7 @@ import { Section } from "@components/Layout"
 import { Dropdown, ImageCarousel } from "@components/Product"
 import { SanityButton } from "@components/Button"
 import PortableText from "@components/PortableText"
+import { QuoteCarousel } from "@components/Quotes"
 
 export const query = graphql`
   query CookbookPage {
@@ -32,9 +33,7 @@ export const query = graphql`
           ...SanityImageAsset
         }
         quotes {
-          name
-          _rawContent
-          yearsAttendedCamp
+          ...SanityQuote
         }
       }
     }
@@ -56,9 +55,12 @@ export default function CookbookPage({
     <>
       <Section>
         <Grid container spacing={3}>
+          {/* Images */}
           <Grid xs={12} md={6}>
             <ImageCarousel images={product?.photos} />
           </Grid>
+
+          {/* Descriptions */}
           <Grid xs={12} md={6}>
             <Stack alignItems="stretch" spacing={2}>
               {/* Headers */}
@@ -74,12 +76,16 @@ export default function CookbookPage({
               <SanityButton content={product?.paymentLinkButton} />
               <PortableText content={product?._rawDescription} />
               <Stack>
-              {product?.additionalDetails?.map((dropdown, i) => (
-                <Dropdown content={dropdown} key={`dropdown-${i}`} />
-              ))}
+                {product?.additionalDetails?.map((dropdown, i) => (
+                  <Dropdown content={dropdown} key={`dropdown-${i}`} />
+                ))}
               </Stack>
-
             </Stack>
+          </Grid>
+
+          {/* Quotes */}
+          <Grid xs={12}>
+            <QuoteCarousel quotes={product?.quotes} />
           </Grid>
         </Grid>
       </Section>

--- a/src/pages/get-involved/cookbook.tsx
+++ b/src/pages/get-involved/cookbook.tsx
@@ -5,7 +5,9 @@ import Grid from "@mui/material/Unstable_Grid2/Grid2"
 
 import getPageTitle from "@utils/getPageTitle"
 import { Section } from "@components/Layout"
-import { ImageCarousel } from "@components/Product"
+import { Dropdown, ImageCarousel } from "@components/Product"
+import { SanityButton } from "@components/Button"
+import PortableText from "@components/PortableText"
 
 export const query = graphql`
   query CookbookPage {
@@ -24,8 +26,7 @@ export const query = graphql`
         }
         _rawDescription
         additionalDetails {
-          dropdownHeader
-          _rawDropdownBody
+          ...SanityDropdown
         }
         photos {
           ...SanityImageAsset
@@ -54,12 +55,33 @@ export default function CookbookPage({
   return (
     <>
       <Section>
-        <Grid container>
+        <Grid container spacing={3}>
           <Grid xs={12} md={6}>
             <ImageCarousel images={product?.photos} />
           </Grid>
+          <Grid xs={12} md={6}>
+            <Stack alignItems="stretch" spacing={2}>
+              {/* Headers */}
+              <Stack>
+                <Typography variant="h4">{product?.name}</Typography>
+                <Typography variant="h5">{product?.subheader}</Typography>
+                <Typography variant="h6">{product?.edition}</Typography>
+              </Stack>
+              {/* Everything Else */}
+              <Typography variant="h6">
+                {`$${product?.price} ${product?.isDonation && "donation"}`}
+              </Typography>
+              <SanityButton content={product?.paymentLinkButton} />
+              <PortableText content={product?._rawDescription} />
+              <Stack>
+              {product?.additionalDetails?.map((dropdown, i) => (
+                <Dropdown content={dropdown} key={`dropdown-${i}`} />
+              ))}
+              </Stack>
+
+            </Stack>
+          </Grid>
         </Grid>
-        <Stack></Stack>
       </Section>
     </>
   )

--- a/src/pages/get-involved/cookbook.tsx
+++ b/src/pages/get-involved/cookbook.tsx
@@ -1,9 +1,11 @@
 import * as React from "react"
 import { PageProps, graphql } from "gatsby"
 import { Stack, Typography } from "@mui/material"
+import Grid from "@mui/material/Unstable_Grid2/Grid2"
 
-import { Section } from "@components/Layout"
 import getPageTitle from "@utils/getPageTitle"
+import { Section } from "@components/Layout"
+import { ImageCarousel } from "@components/Product"
 
 export const query = graphql`
   query CookbookPage {
@@ -47,9 +49,16 @@ export default function CookbookPage({
   if (!sanityCookbookPage)
     throw `No Sanity document for the culture page was found.`
 
+  const product = sanityCookbookPage.productReference
+
   return (
     <>
       <Section>
+        <Grid container>
+          <Grid xs={12} md={6}>
+            <ImageCarousel images={product?.photos} />
+          </Grid>
+        </Grid>
         <Stack></Stack>
       </Section>
     </>

--- a/src/utils/typeUtils.ts
+++ b/src/utils/typeUtils.ts
@@ -1,0 +1,1 @@
+export type Sanity<T> = T | null | undefined

--- a/src/utils/typeUtils.ts
+++ b/src/utils/typeUtils.ts
@@ -1,1 +1,1 @@
-export type Sanity<T> = T | null | undefined
+export type SanityType<T> = T | null | undefined

--- a/yarn.lock
+++ b/yarn.lock
@@ -2049,6 +2049,14 @@
     "@react-spring/shared" "~9.6.1"
     "@react-spring/types" "~9.6.1"
 
+"@react-spring/animated@~9.7.1":
+  version "9.7.1"
+  resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.7.1.tgz#0f2d78184ee0cce703acd41abb87ea56765b5713"
+  integrity sha512-EX5KAD9y7sD43TnLeTNG1MgUVpuRO1YaSJRPawHNRgUWYfILge3s85anny4S4eTJGpdp5OoFV2kx9fsfeo0qsw==
+  dependencies:
+    "@react-spring/shared" "~9.7.1"
+    "@react-spring/types" "~9.7.1"
+
 "@react-spring/core@~9.6.1":
   version "9.6.1"
   resolved "https://registry.yarnpkg.com/@react-spring/core/-/core-9.6.1.tgz#ebe07c20682b360b06af116ea24e2b609e778c10"
@@ -2059,10 +2067,45 @@
     "@react-spring/shared" "~9.6.1"
     "@react-spring/types" "~9.6.1"
 
+"@react-spring/core@~9.7.1":
+  version "9.7.1"
+  resolved "https://registry.yarnpkg.com/@react-spring/core/-/core-9.7.1.tgz#cfe176a48ee0a05545b1af5f2fbae718b50e9a99"
+  integrity sha512-8K9/FaRn5VvMa24mbwYxwkALnAAyMRdmQXrARZLcBW2vxLJ6uw9Cy3d06Z8M12kEqF2bDlccaCSDsn2bSz+Q4A==
+  dependencies:
+    "@react-spring/animated" "~9.7.1"
+    "@react-spring/rafz" "~9.7.1"
+    "@react-spring/shared" "~9.7.1"
+    "@react-spring/types" "~9.7.1"
+
+"@react-spring/konva@~9.7.1":
+  version "9.7.1"
+  resolved "https://registry.yarnpkg.com/@react-spring/konva/-/konva-9.7.1.tgz#25640892f88bde06c3ab96c875e5f7408abbce43"
+  integrity sha512-74svXHtUJi6Tvk9mNLUV1/1WfU8MdWsTK6JUpvmJr/rUr8r3FdOokk22icbgEg6AjxCkIf5e2WFovCCHUSyS0w==
+  dependencies:
+    "@react-spring/animated" "~9.7.1"
+    "@react-spring/core" "~9.7.1"
+    "@react-spring/shared" "~9.7.1"
+    "@react-spring/types" "~9.7.1"
+
+"@react-spring/native@~9.7.1":
+  version "9.7.1"
+  resolved "https://registry.yarnpkg.com/@react-spring/native/-/native-9.7.1.tgz#3f397f946fc9a7dd4d7d432f8c0a4726d7723751"
+  integrity sha512-dHWeH0UuE+Rxc3YZFLp8Aq0RBP07sdOgI7pLVG46OzkMRs2RtJeWJxB6UXIWAgcYDqWDk2REAPhLD3ItDl0tDQ==
+  dependencies:
+    "@react-spring/animated" "~9.7.1"
+    "@react-spring/core" "~9.7.1"
+    "@react-spring/shared" "~9.7.1"
+    "@react-spring/types" "~9.7.1"
+
 "@react-spring/rafz@~9.6.1":
   version "9.6.1"
   resolved "https://registry.yarnpkg.com/@react-spring/rafz/-/rafz-9.6.1.tgz#d71aafb92b78b24e4ff84639f52745afc285c38d"
   integrity sha512-v6qbgNRpztJFFfSE3e2W1Uz+g8KnIBs6SmzCzcVVF61GdGfGOuBrbjIcp+nUz301awVmREKi4eMQb2Ab2gGgyQ==
+
+"@react-spring/rafz@~9.7.1":
+  version "9.7.1"
+  resolved "https://registry.yarnpkg.com/@react-spring/rafz/-/rafz-9.7.1.tgz#bdfea463fcb5ddc4e7253a8fa3870dd52ebbc59a"
+  integrity sha512-JSsrRfbEJvuE3w/uvU3mCTuWwpQcBXkwoW14lBgzK9XJhuxmscGo59AgJUpFkGOiGAVXFBGB+nEXtSinFsopgw==
 
 "@react-spring/shared@~9.6.1":
   version "9.6.1"
@@ -2072,10 +2115,33 @@
     "@react-spring/rafz" "~9.6.1"
     "@react-spring/types" "~9.6.1"
 
+"@react-spring/shared@~9.7.1":
+  version "9.7.1"
+  resolved "https://registry.yarnpkg.com/@react-spring/shared/-/shared-9.7.1.tgz#29611bb63d0c9e1ac18b6ced7aa4db1d48d136f3"
+  integrity sha512-R2kZ+VOO6IBeIAYTIA3C1XZ0ZVg/dDP5FKtWaY8k5akMer9iqf5H9BU0jyt3Qtxn0qQY7whQdf6MTcWtKeaawg==
+  dependencies:
+    "@react-spring/rafz" "~9.7.1"
+    "@react-spring/types" "~9.7.1"
+
+"@react-spring/three@~9.7.1":
+  version "9.7.1"
+  resolved "https://registry.yarnpkg.com/@react-spring/three/-/three-9.7.1.tgz#0dab3b5e96bb6e10db0a1363938e46fc68a861e4"
+  integrity sha512-5leUe0PDwIIw1M3GN3788zwTY4Ykyy+kNvQmg9+Hqs1DN3T8J1ovRTGwqWfGAu4ApTta9p5BH7SWNxxt3NO59Q==
+  dependencies:
+    "@react-spring/animated" "~9.7.1"
+    "@react-spring/core" "~9.7.1"
+    "@react-spring/shared" "~9.7.1"
+    "@react-spring/types" "~9.7.1"
+
 "@react-spring/types@~9.6.1":
   version "9.6.1"
   resolved "https://registry.yarnpkg.com/@react-spring/types/-/types-9.6.1.tgz#913d3a68c5cbc1124fdb18eff919432f7b6abdde"
   integrity sha512-POu8Mk0hIU3lRXB3bGIGe4VHIwwDsQyoD1F394OK7STTiX9w4dG3cTLljjYswkQN+hDSHRrj4O36kuVa7KPU8Q==
+
+"@react-spring/types@~9.7.1":
+  version "9.7.1"
+  resolved "https://registry.yarnpkg.com/@react-spring/types/-/types-9.7.1.tgz#b540752a479d210c6fb68d2b1d5ff35556df4308"
+  integrity sha512-yBcyfKUeZv9wf/ZFrQszvhSPuDx6Py6yMJzpMnS+zxcZmhXPeOCKZSHwqrUz1WxvuRckUhlgb7eNI/x5e1e8CA==
 
 "@react-spring/web@^9.5.5":
   version "9.6.1"
@@ -2086,6 +2152,26 @@
     "@react-spring/core" "~9.6.1"
     "@react-spring/shared" "~9.6.1"
     "@react-spring/types" "~9.6.1"
+
+"@react-spring/web@~9.7.1":
+  version "9.7.1"
+  resolved "https://registry.yarnpkg.com/@react-spring/web/-/web-9.7.1.tgz#a9ee730d06c686b8432cd20f41683b1acb9b6300"
+  integrity sha512-6uUE5MyKqdrJnIJqlDN/AXf3i8PjOQzUuT26nkpsYxUGOk7c+vZVPcfrExLSoKzTb9kF0i66DcqzO5fXz/Z1AA==
+  dependencies:
+    "@react-spring/animated" "~9.7.1"
+    "@react-spring/core" "~9.7.1"
+    "@react-spring/shared" "~9.7.1"
+    "@react-spring/types" "~9.7.1"
+
+"@react-spring/zdog@~9.7.1":
+  version "9.7.1"
+  resolved "https://registry.yarnpkg.com/@react-spring/zdog/-/zdog-9.7.1.tgz#474a1366d7b71d623e0dff0e37a243b505e8c1a6"
+  integrity sha512-FeDws+7ZSoi91TUjxKnq3xmdOW6fthmqky6zSPIZq1NomeyO7+xwbxjtu15IqoWG4DJ9pouVZDijvBQXUNl0Mw==
+  dependencies:
+    "@react-spring/animated" "~9.7.1"
+    "@react-spring/core" "~9.7.1"
+    "@react-spring/shared" "~9.7.1"
+    "@react-spring/types" "~9.7.1"
 
 "@sanity/client@^3.4.1":
   version "3.4.1"
@@ -2536,6 +2622,18 @@
   dependencies:
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
+
+"@use-gesture/core@10.2.25":
+  version "10.2.25"
+  resolved "https://registry.yarnpkg.com/@use-gesture/core/-/core-10.2.25.tgz#5f21c28c4f0bf1a1be87f2ac8bb49ad39dfd818b"
+  integrity sha512-tn01i1//mZrv+9VwyGB4KiuA6fQWvPfzwJNwcjxtMBeW0ELBukXOimvdm3hztxkpVwlz8dhQnXzkjtsxSpe9VA==
+
+"@use-gesture/react@^10.2.11":
+  version "10.2.25"
+  resolved "https://registry.yarnpkg.com/@use-gesture/react/-/react-10.2.25.tgz#e0ca154bfe5792ef4fd8a831e983212867dd37bb"
+  integrity sha512-DCxBNxILAFPp74O5f0zhXshmf5Vur4sKJmNX+gbNvg2mdJgch6iWRmahsDE1BqeaTgwZL/gwKIbl5VsP6PTgVg==
+  dependencies:
+    "@use-gesture/core" "10.2.25"
 
 "@vercel/webpack-asset-relocator-loader@^1.7.0":
   version "1.7.3"
@@ -8280,6 +8378,27 @@ react-server-dom-webpack@0.0.0-experimental-c8b778b7f-20220825:
     loose-envify "^1.1.0"
     neo-async "^2.6.1"
 
+react-spring-carousel@^2.0.19:
+  version "2.0.19"
+  resolved "https://registry.yarnpkg.com/react-spring-carousel/-/react-spring-carousel-2.0.19.tgz#a110bc51f7fb036cc1c68f6378155a8490f7ddc6"
+  integrity sha512-OiSTuxjLv0whsjLWnZFkhCZXfaNFgBOZHr8EmggZqVZ5z+78zB87C0gTwyBA86Vo/Uljlvez6ELwLszj8fDa9A==
+  dependencies:
+    "@use-gesture/react" "^10.2.11"
+    rxjs "^7.5.4"
+    screenfull "^5.2.0"
+
+react-spring@^9.7.1:
+  version "9.7.1"
+  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-9.7.1.tgz#8acfed700823490a4d9d4cf131c5fea12d1aaa93"
+  integrity sha512-o2+r2DNQDVEuefiz33ZF76DPd/gLq3kbdObJmllGF2IUfv2W6x+ZP0gR97QYCSR4QLbmOl1mPKUBbI+FJdys2Q==
+  dependencies:
+    "@react-spring/core" "~9.7.1"
+    "@react-spring/konva" "~9.7.1"
+    "@react-spring/native" "~9.7.1"
+    "@react-spring/three" "~9.7.1"
+    "@react-spring/web" "~9.7.1"
+    "@react-spring/zdog" "~9.7.1"
+
 react-transition-group@^4.4.5:
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
@@ -8595,6 +8714,13 @@ rxjs@^6.0.0, rxjs@^6.6.0, rxjs@^6.6.7:
   dependencies:
     tslib "^1.9.0"
 
+rxjs@^7.5.4:
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.0.tgz#90a938862a82888ff4c7359811a595e14e1e09a4"
+  integrity sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==
+  dependencies:
+    tslib "^2.1.0"
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -8662,6 +8788,11 @@ schema-utils@^3.0.0, schema-utils@^3.1.0, schema-utils@^3.1.1:
     "@types/json-schema" "^7.0.8"
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
+
+screenfull@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-5.2.0.tgz#6533d524d30621fc1283b9692146f3f13a93d1ba"
+  integrity sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==
 
 semver@7.0.0:
   version "7.0.0"


### PR DESCRIPTION
# Preview
![image](https://user-images.githubusercontent.com/8130932/229096019-3d66d6ef-1b7c-4bde-9935-b41efbf3a62d.png)

# This PR
Oops I accidentally made this PR too big but it accomplishes the following.
- Adds a utility TS type `SanityType` that we can use anytime we want to get the optional fields from Sanity
- Adds the cookbook page which displays the product linked in the CMS (right now that's the cookbook)
- Adds an image carousel for the product page
  - Still need to add full screen support
  - Still need to add the image overflow
  - Eh sometimes on large screens the image previews overflow past the main image
- Adds the text
- Adds a dropdown component
- Adds a Quote and Quote carousel component
  - Uses `react-spring-carousel` which has some [pretty nice docs](https://react-spring-carousel.emilianobucci.com/)

Sorry this PR is massive. I promise I don't put up code like this for work 😅
