### PR TITLE
Font Improvements + Others

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -36,7 +36,8 @@ const config: GatsbyConfig = {
       resolve: "gatsby-plugin-web-font-loader",
       options: {
         google: {
-          families: ["Nunito"],
+          families: ["Nunito: 200,500,700,800,900,1000"],
+          
         },
       },
     },

--- a/src/components/App/theme.ts
+++ b/src/components/App/theme.ts
@@ -1,27 +1,32 @@
-import { createTheme, PaletteColorOptions, responsiveFontSizes } from "@mui/material"
+import {
+  createTheme,
+  PaletteColorOptions,
+  responsiveFontSizes,
+} from "@mui/material"
 
 const TEAL: PaletteColorOptions = {
-  main: '#29A19D',
-  light: '#A2E8E5',
-  dark: '#046A67',
-  contrastText: '#FFFFFF',
+  main: "#29A19D",
+  light: "#A2E8E5",
+  dark: "#046A67",
+  contrastText: "#FFFFFF",
 }
 
 const SAFFRON_YELLOW: PaletteColorOptions = {
-  main: '#FFCA43',
-  light: '#FFE6A7',
-  dark: '#D09600',
+  main: "#FFCA43",
+  light: "#FFE6A7",
+  dark: "#D09600",
 }
 
 const PINK: PaletteColorOptions = {
-  main: '#E95984',
-  light: '#FFC3DA',
-  dark: '#DA0758',
-  contrastText: '#FFFFFF',
+  main: "#E95984",
+  light: "#FFC3DA",
+  dark: "#DA0758",
+  contrastText: "#FFFFFF",
 }
 
 const bodyFontFamily = {
   fontFamily: "Arial, sans-serif",
+  lineHeight: "24px",
 }
 
 const theme = createTheme({
@@ -30,39 +35,40 @@ const theme = createTheme({
     secondary: SAFFRON_YELLOW,
     tertiary: TEAL,
     gray: "#514B4D",
-    offwhite: "#F8F2F4"
+    offwhite: "#F8F2F4",
   },
   shape: {
-    borderRadius: 4
+    borderRadius: 4,
   },
   typography: {
     fontFamily: '"Nunito", -apple-system, sans-serif',
     h1: {
-      fontWeight: 700,
+      fontWeight: 1000,
     },
     h2: {
-      fontWeight: 700,
+      fontWeight: 1000,
     },
     h3: {
-      fontWeight: 700,
+      fontWeight: 900,
     },
     h4: {
-      fontWeight: 700,
+      fontWeight: 800,
     },
     h5: {
-      fontWeight: 700
+      fontWeight: 700,
     },
     h6: {
       fontWeight: 700,
     },
-    subtitle1: bodyFontFamily,
-    body1: bodyFontFamily,
-    body2: bodyFontFamily,
+    subtitle1: { letterSpacing: "0.15px", ...bodyFontFamily },
+    subtitle2: { letterSpacing: "0.1px", ...bodyFontFamily },
+    body1: { letterSpacing: "0.15px", ...bodyFontFamily },
+    body2: { letterSpacing: "0.15px", ...bodyFontFamily },
     button: {
       textTransform: "capitalize",
       fontWeight: 700,
-    }
-  }
+    },
+  },
 })
 
 export default responsiveFontSizes(theme)

--- a/src/components/App/theme.ts
+++ b/src/components/App/theme.ts
@@ -69,6 +69,16 @@ const theme = createTheme({
       fontWeight: 700,
     },
   },
+  breakpoints: {
+    values: {
+      xs: 0,
+      sm: 600,
+      md: 900,
+      lg: 1200,
+      xl: 1536,
+      xxl: 2000,
+    }
+  }
 })
 
 export default responsiveFontSizes(theme)

--- a/src/components/Button/SanityButton.tsx
+++ b/src/components/Button/SanityButton.tsx
@@ -15,12 +15,11 @@ export const sanityButtonFragment = graphql`
 
 type SanityButtonProps = Omit<ButtonProps, "href" | "variant" | "ref" | "content"> & {
   content: Queries.SanityButtonFragment | null | undefined
-  isAnimated?: boolean
   boopProps?: BoopProps
 }
 
 const SanityButton = React.forwardRef<HTMLButtonElement, SanityButtonProps>(
-  ({ content, isAnimated = false, boopProps, ...rest }, ref) => {
+  ({ content, boopProps, ...rest }, ref) => {
     if (!content?.text) {
       console.debug("No content found for the button")
       return <></>
@@ -34,7 +33,7 @@ const SanityButton = React.forwardRef<HTMLButtonElement, SanityButtonProps>(
       ...rest,
     }
 
-    return isAnimated && boopProps ? (
+    return boopProps ? (
       <AnimatedButton boopProps={boopProps} {...sharedProps}>
         {text}
       </AnimatedButton>

--- a/src/components/Card/AlternatingContentGrid.tsx
+++ b/src/components/Card/AlternatingContentGrid.tsx
@@ -30,9 +30,7 @@ export default function AlternatingContentGrid({
         const Image = (
           <SanityImage imageAsset={card?.image} style={{ width: "100%" }} />
         )
-        const ColoredBar = (
-          <Box height={1} width={12} borderRadius={2} bgcolor={color} />
-        )
+        const ColoredBar = <Box width={12} borderRadius={2} bgcolor={color} />
 
         return (
           <Grid
@@ -44,17 +42,16 @@ export default function AlternatingContentGrid({
             // justifyContent={index % 2 === 0 ? "flex-start" : "flex-end"}
           >
             {(index % 2 === 0 || !matches) && (
-              <Grid
-                xs={12}
-                md={6}
-                component={Stack}
-                direction="row"
-                spacing={1}
-                alignItems="stretch"
-                justifyContent="flex-start"
-              >
-                {ColoredBar}
-                {Image}
+              <Grid xs={12} md={6}>
+                <Stack
+                  direction="row"
+                  spacing={1}
+                  alignItems="stretch"
+                  justifyContent="flex-start"
+                >
+                  {ColoredBar}
+                  {Image}
+                </Stack>
               </Grid>
             )}
             <Grid
@@ -69,17 +66,16 @@ export default function AlternatingContentGrid({
               </Stack>
             </Grid>
             {index % 2 === 1 && matches && (
-              <Grid
-                xs={12}
-                md={6}
-                component={Stack}
-                direction="row"
-                spacing={1}
-                alignItems="stretch"
-                justifyContent="flex-end"
-              >
-                {Image}
-                {ColoredBar}
+              <Grid xs={12} md={6}>
+                <Stack
+                  direction="row"
+                  spacing={1}
+                  alignItems="stretch"
+                  justifyContent="flex-end"
+                >
+                  {Image}
+                  {ColoredBar}
+                </Stack>
               </Grid>
             )}
           </Grid>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -14,14 +14,14 @@ const FooterLinks = [
   [
     {
       text: "About LYF",
-      to: "/about-us/history",
+      to: "/camp/lyf-camp",
     },
     {
-      text: "About LYF",
-      to: "/about-us/history",
+      text: "Culture",
+      to: "/about-us/culture",
     },
     {
-      text: "About LYF",
+      text: "History of LYF",
       to: "/about-us/history",
     },
   ],
@@ -45,12 +45,12 @@ const FooterLinks = [
       to: "/camp/faqs",
     },
     {
-      text: "About LYF",
-      to: "/about-us/history",
+      text: "Leadership",
+      to: "/about-us/leadership",
     },
     {
-      text: "About LYF",
-      to: "/about-us/history",
+      text: "Contact Us",
+      to: "/",
     },
   ],
 ]

--- a/src/components/IndexPage/Goals.tsx
+++ b/src/components/IndexPage/Goals.tsx
@@ -25,7 +25,7 @@ export default function Goals({ goals }: GoalsProps) {
     <Grid container justifyContent="space-between" alignItems="flex-start">
       {goals.map((goal, index) => (
         <Grid xs={12} md={2} key={goal}>
-          <Stack>
+          <Stack spacing={1}>
             {icons[index % 5]}
             <Typography variant="h6">{goal}</Typography>
           </Stack>

--- a/src/components/Leadership/LeadershipPerson.tsx
+++ b/src/components/Leadership/LeadershipPerson.tsx
@@ -3,9 +3,9 @@ import React from "react"
 import { graphql } from "gatsby"
 import { Box, Stack, Typography } from "@mui/material"
 import SanityGatsbyImage from "gatsby-plugin-sanity-image"
+import useMeasure from "react-use-measure"
 
 import { SanityType } from "@utils/typeUtils"
-import { PortraitImage } from "@components/Image"
 
 export const sanityLeadershipPersonFragment = graphql`
   fragment SanityLeadershipPerson on SanityPerson {
@@ -27,18 +27,47 @@ export default function LeadershipPerson({
   backgroundColor,
 }: LeadershipPersonProps) {
   const propic = person?.propic
+  const [ref, bounds] = useMeasure()
+
   return (
-    <Stack spacing={2}>
+    <Stack spacing={2} ref={ref}>
       {propic ? (
-        <SanityGatsbyImage
-          {...propic}
-          width={200}
-          height={200}
-          style={{
-            borderRadius: "50%",
-            boxShadow: `8px 12px 0px ${backgroundColor}`
-          }}
-        />
+        <Box sx={{
+          position: "relative",
+          width: bounds.width,
+          height: bounds.width,
+          display: "inline-block",
+        }}>
+          <Box
+            sx={{
+              width: 1,
+              height: 1,
+              position: "absolute",
+              opacity: 1,
+              borderRadius: "50%",
+              boxShadow: `8px 12px 0px ${backgroundColor}`,
+              top: 0,
+              left: 0,
+              zIndex: 0,
+            }}
+          />
+          <SanityGatsbyImage
+            {...propic}
+            width={200}
+            height={200}
+            loading="lazy"
+            style={{
+              borderRadius: "50%",
+              position: "absolute",
+              boxShadow: `8px 12px 0px ${backgroundColor}`,
+              top: 0,
+              right: 0,
+              width: "100%",
+              height: "100%",
+              zIndex: 100,
+            }}
+          />
+        </Box>
       ) : (
         <></>
       )}

--- a/src/components/Link/LinkWithIcon.tsx
+++ b/src/components/Link/LinkWithIcon.tsx
@@ -25,8 +25,8 @@ const LinkWithIcon = React.forwardRef<HTMLAnchorElement, LinkWithIconProps>(
         onMouseEnter={trigger}
         {...rest}
       >
-        <Stack direction="row" justifyContent={justifyContent}>
-          {text}
+        <Stack direction="row" justifyContent={justifyContent} alignItems="center" spacing={1}>
+          <Typography variant="h6">{text}</Typography>
           <AnimatedIcon style={boopStyles} fontSize="small" />
         </Stack>
       </MuiLink>

--- a/src/components/WholePersonLeadership/VennDiagram.tsx
+++ b/src/components/WholePersonLeadership/VennDiagram.tsx
@@ -58,7 +58,7 @@ export default function VennDiagram() {
         fill={palette.secondary.main}
         {...firstSpring}
       ></a.ellipse>
-      <Text x={80} y={320}>
+      <Text x={65} y={320}>
         Identity & Development
       </Text>
 

--- a/src/components/WholePersonLeadership/WholePersonLeadership.tsx
+++ b/src/components/WholePersonLeadership/WholePersonLeadership.tsx
@@ -74,10 +74,7 @@ export default function WholePersonLeadership({}: WholePersonLeadershipProps) {
                 container
                 key={name}
                 columnSpacing={1}
-                rowSpacing={0}
-                sx={{
-                  padding: 0,
-                }}
+                rowSpacing={1}
               >
                 <Grid>
                   {/* @ts-ignore Tertiary added via module augmentation but doesn't show up here. */}

--- a/src/components/YouTubeEmbed/CampOverlayVideo.tsx
+++ b/src/components/YouTubeEmbed/CampOverlayVideo.tsx
@@ -3,14 +3,18 @@ import React from "react"
 import { Box } from "@mui/material"
 import useMeasure from "react-use-measure"
 
+import { SanityType } from "@utils/typeUtils"
 import YouTubeEmbed from "./YouTubeEmbed"
 import "./YouTubeBorderRadius.css"
 
 type CampOverlayVideoProps = {
-  url: string
+  url: SanityType<string>
 }
 
 export default function CampOverlayVideo({ url }: CampOverlayVideoProps) {
+  if (!url) {
+    return <></>
+  }
   const [ref, bounds] = useMeasure()
   return (
     <Box ref={ref} sx={{ width: 1, height: 1, borderRadius: 4 }}>

--- a/src/components/YouTubeEmbed/YouTubeEmbed.tsx
+++ b/src/components/YouTubeEmbed/YouTubeEmbed.tsx
@@ -31,7 +31,6 @@ export default function YouTubeEmbed({
   ...rest
 }: YouTubeEmbedProps) {
   const youtubeId = extractYouTubeId(url)
-  console.log(youtubeId)
   return (
     <YouTube
       videoId={youtubeId}

--- a/src/pages/get-involved/join-our-team.tsx
+++ b/src/pages/get-involved/join-our-team.tsx
@@ -77,7 +77,6 @@ export default function JoinOurTeamPage({
                 {sanityJoinOurTeamPage?.subHeader}
               </Typography>
               <SanityButton
-                isAnimated
                 boopProps={{ scale: 1.1 }}
                 content={sanityJoinOurTeamPage.headerButton}
               ></SanityButton>
@@ -161,7 +160,6 @@ export default function JoinOurTeamPage({
             {sanityJoinOurTeamPage?.interestForm}
           </Typography>
           <SanityButton
-            isAnimated
             boopProps={{ scale: 1.1 }}
             content={sanityJoinOurTeamPage.interestFormButton}
           ></SanityButton>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -141,7 +141,7 @@ export default function IndexPage({ data }: PageProps<Queries.IndexPageQuery>) {
 
       {/* What is LYF Camp? */}
       <Section backgroundColor="#F2F2F2">
-        <Grid container spacing={2} justifyContent="space-between">
+        <Grid container spacing={2} justifyContent="space-between" alignItems="center">
           <Grid xs={12} md={4}>
             <Stack spacing={8}>
               <Typography variant="h3" textAlign={{ xs: "center", md: "left" }}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -68,16 +68,14 @@ export default function IndexPage({ data }: PageProps<Queries.IndexPageQuery>) {
   return (
     <Stack alignItems="stretch">
       {/* Hero Section */}
-      <Section maxWidth={false}>
+      <Section maxWidth="xxl">
         <Grid
           container
-          alignItems="center"
           justifyContent="space-between"
           flexWrap="wrap"
-          gap={2}
         >
           {/* Header */}
-          <Grid xs={12} md={6}>
+          <Grid xs={12} md={8}>
             <Typography
               variant="h1"
               textAlign={{
@@ -89,8 +87,8 @@ export default function IndexPage({ data }: PageProps<Queries.IndexPageQuery>) {
             </Typography>
           </Grid>
           {/* SubHeader */}
-          <Grid xs={12} md={5}>
-            <Stack spacing={2} alignItems={{ xs: "center", md: "self-start" }}>
+          <Grid xs={12} md={4}>
+            <Stack spacing={2} alignItems={{ xs: "center", md: "self-start" }} sx={{paddingTop: 4}}>
               <Typography
                 variant="h4"
                 textAlign={{
@@ -104,9 +102,7 @@ export default function IndexPage({ data }: PageProps<Queries.IndexPageQuery>) {
               <SanityButton
                 boopProps={{ scale: 1.1 }}
                 content={sanityHomePage.subHeaderButton}
-                sx={{
-                  padding: 2,
-                }}
+                size="large"
               >
                 Register
               </SanityButton>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -79,7 +79,7 @@ export default function IndexPage({ data }: PageProps<Queries.IndexPageQuery>) {
           {/* Header */}
           <Grid xs={12} md={6}>
             <Typography
-              variant="h2"
+              variant="h1"
               textAlign={{
                 xs: "center",
                 md: "left",
@@ -104,6 +104,9 @@ export default function IndexPage({ data }: PageProps<Queries.IndexPageQuery>) {
               <SanityButton
                 boopProps={{ scale: 1.1 }}
                 content={sanityHomePage.subHeaderButton}
+                sx={{
+                  padding: 2,
+                }}
               >
                 Register
               </SanityButton>
@@ -205,7 +208,6 @@ export default function IndexPage({ data }: PageProps<Queries.IndexPageQuery>) {
                 content={sanityHomePage._rawCtaBody}
               />
               <SanityButton
-                isAnimated
                 boopProps={{ scale: 1.1 }}
                 content={sanityHomePage.ctaLink}
               />

--- a/src/types/theme.d.ts
+++ b/src/types/theme.d.ts
@@ -12,4 +12,13 @@ declare module "@mui/material/styles" {
     gray: string,
     offwhite: string,
   }
+
+  interface BreakpointOverrides {
+    xs: true;
+    sm: true;
+    md: true;
+    lg: true;
+    xl: true;
+    xxl: true;
+  }
 }


### PR DESCRIPTION
Oops I accidentally added way too much into this one PR but it accomplishes a lot of polish for the site

1. Adds proper font variants/bolding for the different headers
2. Fixed spacing for various components
3. Adds the "xxl" breakpoint which we can use when we want a section to span slightly larger (like the home page's main header)
4. Removes the isAnimated prop from SanityButton since it can be implied from boopProps
5. Fixed the leadership page's images starting out as ellipses which causes this jarring load