### PR TITLE
Add animations and various optimizations to home page

### DIFF
--- a/gatsby-browser.tsx
+++ b/gatsby-browser.tsx
@@ -7,5 +7,9 @@ import React from "react"
 
 import { Providers, Layout } from "./src/components/App"
 
+// Import all the font variants
+import "@fontsource/nunito/800.css"
+import "@fontsource/nunito/700.css"
+
 export const wrapRootElement = ({ element }) => <Providers>{element}</Providers>
 export const wrapPageElement = ({ element }) => <Layout>{element}</Layout>

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -32,15 +32,6 @@ const config: GatsbyConfig = {
       },
     },
     "gatsby-transformer-sharp",
-    {
-      resolve: "gatsby-plugin-web-font-loader",
-      options: {
-        google: {
-          families: ["Nunito: 200,500,700,800,900,1000"],
-          
-        },
-      },
-    },
   ],
 }
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
+    "@fontsource/nunito": "^5.0.0",
     "@mui/icons-material": "^5.10.9",
     "@mui/material": "^5.10.12",
     "@portabletext/react": "^3.0.0",
@@ -27,7 +28,6 @@
     "gatsby-plugin-image": "^3.3.2",
     "gatsby-plugin-sanity-image": "^0.13.4",
     "gatsby-plugin-sharp": "^5.0.0",
-    "gatsby-plugin-web-font-loader": "^1.0.4",
     "gatsby-source-filesystem": "^5.0.0",
     "gatsby-source-sanity": "^7.6.1",
     "gatsby-transformer-sharp": "^5.0.0",

--- a/src/components/App/theme.ts
+++ b/src/components/App/theme.ts
@@ -41,7 +41,7 @@ const theme = createTheme({
     borderRadius: 4,
   },
   typography: {
-    fontFamily: '"Nunito", -apple-system, sans-serif',
+    fontFamily: '"Nunito", Arial, -apple-system, sans-serif',
     h1: {
       fontWeight: 1000,
     },

--- a/src/components/App/theme.ts
+++ b/src/components/App/theme.ts
@@ -43,16 +43,16 @@ const theme = createTheme({
   typography: {
     fontFamily: '"Nunito", Arial, -apple-system, sans-serif',
     h1: {
-      fontWeight: 1000,
+      fontWeight: 800,
     },
     h2: {
-      fontWeight: 1000,
+      fontWeight: 800,
     },
     h3: {
-      fontWeight: 900,
+      fontWeight: 800,
     },
     h4: {
-      fontWeight: 800,
+      fontWeight: 700,
     },
     h5: {
       fontWeight: 700,

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,8 +1,7 @@
 import * as React from "react"
-import { Box, Stack, Typography } from "@mui/material"
+import { Box, Stack } from "@mui/material"
 import { Instagram, Facebook } from "@mui/icons-material"
 import Grid from "@mui/material/Unstable_Grid2"
-import { Link } from "gatsby"
 
 import FooterText from "./FooterText"
 import FooterLink from "./FooterLink"
@@ -77,12 +76,10 @@ export default function Footer() {
         </Grid>
         <Grid container xs={12} md={6} columnSpacing={6} rowSpacing={2}>
           {FooterLinks.map((link, i) => (
-            <Grid key={`footerLinkStack-${i}`}>
-              <Stack>
+            <Grid key={`footerLinkStack-${i}`} component={Stack}>
                 {link.map(({ text, to }, j) => (
                   <FooterLink to={to} key={`${to}-${j}`} text={text} />
                 ))}
-              </Stack>
             </Grid>
           ))}
         </Grid>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -4,11 +4,8 @@ import { Instagram, Facebook } from "@mui/icons-material"
 import Grid from "@mui/material/Unstable_Grid2"
 import { Link } from "gatsby"
 
-const FooterText = ({ text }: { text: string }) => (
-  <Typography variant="h6" color="white">
-    {text}
-  </Typography>
-)
+import FooterText from "./FooterText"
+import FooterLink from "./FooterLink"
 
 const FooterLinks = [
   [
@@ -83,11 +80,7 @@ export default function Footer() {
             <Grid key={`footerLinkStack-${i}`}>
               <Stack>
                 {link.map(({ text, to }, j) => (
-                  <Link to={to} key={`${to}-${j}`} style={{
-                    textDecoration: "none"
-                  }}>
-                    <FooterText text={text} />
-                  </Link>
+                  <FooterLink to={to} key={`${to}-${j}`} text={text} />
                 ))}
               </Stack>
             </Grid>

--- a/src/components/Footer/FooterLink.tsx
+++ b/src/components/Footer/FooterLink.tsx
@@ -1,0 +1,43 @@
+import React from "react"
+
+import { Box, Stack } from "@mui/material"
+import { useSpring, animated, config } from "@react-spring/web"
+import { Link } from "gatsby"
+
+import FooterText from "./FooterText"
+import useMouseOver from "@hooks/useMouseOver"
+
+type FooterLinkProps = {
+  text: string
+  to: string
+}
+
+const AnimatedBox = animated(Box)
+
+export default function FooterLink({ text, to }: FooterLinkProps) {
+  const [isMouseOver, onMouseEnter, onMouseLeave] = useMouseOver()
+  const spring = useSpring({
+    width: isMouseOver ? "100%" : "0%",
+    height: "4px",
+    backgroundColor: "white",
+    config: {
+      clamp: true,
+      ...config.stiff
+    }
+  })
+
+  return (
+    <Stack onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+      <FooterText
+        text={text}
+        // @ts-ignore For some reason type doesn't like Link as a component
+        component={Link}
+        to={to}
+        style={{
+          textDecoration: "none",
+        }}
+      />
+      <AnimatedBox style={spring}/>
+    </Stack>
+  )
+}

--- a/src/components/Footer/FooterText.tsx
+++ b/src/components/Footer/FooterText.tsx
@@ -1,0 +1,18 @@
+import React from "react"
+
+import { Typography, TypographyProps } from "@mui/material"
+
+type FooterTextProps = Omit<TypographyProps, "variant" | "color"> & {
+  text: string
+}
+
+export default function FooterText({
+  text,
+  ...rest
+}: FooterTextProps) {
+  return (
+    <Typography variant="h6" color="white" {...rest}>
+      {text}
+    </Typography>
+  )
+}

--- a/src/components/IndexPage/Goals.tsx
+++ b/src/components/IndexPage/Goals.tsx
@@ -23,7 +23,7 @@ export default function Goals({ goals }: GoalsProps) {
     return <></>
   }
 
-  const [ref, inView] = useInView({ once: false })
+  const [ref, inView] = useInView({ once: true })
   const [trails, __] = useTrail(
     goals.length,
     () => ({
@@ -43,11 +43,17 @@ export default function Goals({ goals }: GoalsProps) {
       ref={ref}
     >
       {goals.map((goal, index) => (
-        <Grid xs={12} sm={6} md={2} key={goal}>
-          <AnimatedStack spacing={1} style={trails[index]}>
-            {icons[index % 5]}
-            <Typography variant="h6">{goal}</Typography>
-          </AnimatedStack>
+        <Grid
+          xs={12}
+          sm={6}
+          md={2}
+          key={goal}
+          component={AnimatedStack}
+          spacing={1}
+          style={trails[index]}
+        >
+          {icons[index % 5]}
+          <Typography variant="h6">{goal}</Typography>
         </Grid>
       ))}
     </Grid>

--- a/src/components/IndexPage/Goals.tsx
+++ b/src/components/IndexPage/Goals.tsx
@@ -2,10 +2,13 @@ import * as React from "react"
 import { Stack, Typography } from "@mui/material"
 import { ChatBubble, Twitter, Psychology, Handshake } from "@mui/icons-material"
 import Grid from "@mui/material/Unstable_Grid2"
+import { animated, useInView, useTrail } from "@react-spring/web"
 
 type GoalsProps = {
   goals: readonly (string | null)[] | null
 }
+
+const AnimatedStack = animated(Stack)
 
 const icons = [
   <ChatBubble color="primary" fontSize="large" />,
@@ -20,15 +23,31 @@ export default function Goals({ goals }: GoalsProps) {
     return <></>
   }
 
+  const [ref, inView] = useInView({ once: false })
+  const [trails, __] = useTrail(
+    goals.length,
+    () => ({
+      translateX: inView ? 0 : -20,
+      opacity: inView ? 1 : 0,
+    }),
+    [inView]
+  )
+
   // Assume we're given 6 photos.
   return (
-    <Grid container justifyContent="space-between" alignItems="flex-start" spacing={2}>
+    <Grid
+      container
+      justifyContent="space-between"
+      alignItems="flex-start"
+      spacing={2}
+      ref={ref}
+    >
       {goals.map((goal, index) => (
         <Grid xs={12} sm={6} md={2} key={goal}>
-          <Stack spacing={1}>
+          <AnimatedStack spacing={1} style={trails[index]}>
             {icons[index % 5]}
             <Typography variant="h6">{goal}</Typography>
-          </Stack>
+          </AnimatedStack>
         </Grid>
       ))}
     </Grid>

--- a/src/components/IndexPage/PhotoGrid.tsx
+++ b/src/components/IndexPage/PhotoGrid.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { Box, Stack } from "@mui/material"
 import Grid from "@mui/material/Unstable_Grid2"
 import SanityImage from "@components/Image/SanityImage"
-import { animated, useSprings, config } from "@react-spring/web"
+import { animated, useSprings } from "@react-spring/web"
 
 const ColoredBar = ({ color }: { color: string }) => (
   <Box

--- a/src/components/IndexPage/Statistics.tsx
+++ b/src/components/IndexPage/Statistics.tsx
@@ -24,7 +24,7 @@ const Stat = ({number, decorator, caption}: StatProps) => {
   const value = useSpringValue(0, {
     config: config.molasses
   })
-  const [ref, inView] = useInView()
+  const [ref, inView] = useInView({once: true})
   React.useEffect(() => {
     value.start(inView ? number : 0)
   }, [inView])

--- a/src/components/Layout/FadeIn.tsx
+++ b/src/components/Layout/FadeIn.tsx
@@ -40,8 +40,8 @@ export default function FadeIn({
   })
 
   return (
-    <animated.div ref={ref} style={springs}>
+    <animated.span ref={ref} style={springs}>
       {children}
-    </animated.div>
+    </animated.span>
   )
 }

--- a/src/components/Layout/FadeIn.tsx
+++ b/src/components/Layout/FadeIn.tsx
@@ -1,0 +1,47 @@
+import React from "react"
+
+import { useInView, animated, SpringConfig, config } from "@react-spring/web"
+
+type FadeInProps = React.PropsWithChildren<{
+  translateX?: number
+  translateY?: number
+  opacity?: number
+  delay?: number
+  repeatEveryView?: boolean
+  springConfig?: SpringConfig
+}>
+
+export default function FadeIn({
+  translateX = 0,
+  translateY = 0,
+  opacity = 0,
+  delay = 0,
+  repeatEveryView = false,
+  springConfig = config.slow,
+  children,
+}: FadeInProps) {
+  const [ref, springs] = useInView(() => ({
+    from: {
+      translateX,
+      translateY,
+      opacity,
+    },
+    to: {
+      translateX: 0,
+      translateY: 0,
+      opacity: 1,
+    },
+    delay: delay,
+    config: springConfig,
+  }), {
+    // once: !repeatEveryView,
+    // Turn this on when developing so you're not constantly refreshing the page.
+    once: false,
+  })
+
+  return (
+    <animated.div ref={ref} style={springs}>
+      {children}
+    </animated.div>
+  )
+}

--- a/src/components/Layout/FadeIn.tsx
+++ b/src/components/Layout/FadeIn.tsx
@@ -40,8 +40,8 @@ export default function FadeIn({
   })
 
   return (
-    <animated.span ref={ref} style={springs}>
+    <animated.div ref={ref} style={springs}>
       {children}
-    </animated.span>
+    </animated.div>
   )
 }

--- a/src/components/Layout/FadeIn.tsx
+++ b/src/components/Layout/FadeIn.tsx
@@ -34,9 +34,9 @@ export default function FadeIn({
     delay: delay,
     config: springConfig,
   }), {
-    // once: !repeatEveryView,
+    once: !repeatEveryView,
     // Turn this on when developing so you're not constantly refreshing the page.
-    once: false,
+    // once: false,
   })
 
   return (

--- a/src/components/Layout/index.ts
+++ b/src/components/Layout/index.ts
@@ -1,1 +1,2 @@
 export { default as Section } from "./Section"
+export { default as FadeIn } from "./FadeIn"

--- a/src/components/Quotes/Quote.tsx
+++ b/src/components/Quotes/Quote.tsx
@@ -59,7 +59,7 @@ export default function Quote({ content, color, isSelected }: QuoteProps) {
               minHeaderSize="h6"
               sx={{
                 maxHeight: "55vh",
-                overflow: "scroll",
+                overflow: "auto",
               }}
             />
           </Stack>

--- a/src/components/WholePersonLeadership/VennDiagram.tsx
+++ b/src/components/WholePersonLeadership/VennDiagram.tsx
@@ -7,6 +7,7 @@ import {
   config,
   SpringRef,
   SpringValue,
+  useInView,
 } from "@react-spring/web"
 import { useTheme, styled } from "@mui/material"
 
@@ -35,14 +36,22 @@ function useSpringAndRef(radius: number): [SpringRef, EllipseSpring] {
 
 export default function VennDiagram() {
   const { shape, palette } = useTheme()
+  const [ref, inView] = useInView({ once: false })
 
   // We create three spring configs
   const [firstSpringRef, firstSpring] = useSpringAndRef(160)
   const [secondSpringRef, secondSpring] = useSpringAndRef(175)
   const [thirdSpringRef, thirdSpring] = useSpringAndRef(206)
 
-  // Now chain those springs together at specific offset (0-1) times
-  useChain([firstSpringRef, secondSpringRef, thirdSpringRef], [0, 0.4, 0.8])
+  // I would do this with useChain but they don't allow in view starting
+  // so I've mimicked it myself. Note that because we do "once" we won't
+  // allow setTimeout to conflict with itself.
+  React.useEffect(() => {
+    if (inView) {
+      firstSpringRef.start(), setTimeout(() => secondSpringRef.start(), 400)
+      setTimeout(() => thirdSpringRef.start(), 800)
+    }
+  }, [inView, firstSpringRef, secondSpringRef, thirdSpringRef])
 
   return (
     <svg
@@ -51,6 +60,7 @@ export default function VennDiagram() {
         borderRadius: shape.borderRadius * 2,
         backgroundColor: "#F8F2F4",
       }}
+      ref={ref}
     >
       <a.ellipse
         cx="194"

--- a/src/components/WholePersonLeadership/WholePersonLeadership.tsx
+++ b/src/components/WholePersonLeadership/WholePersonLeadership.tsx
@@ -68,7 +68,7 @@ export default function WholePersonLeadership({}: WholePersonLeadershipProps) {
           >
             Built by the current TA generation for the next generation
           </Typography>
-          <Stack spacing={5}>
+          <Stack spacing={5} padding={1}>
             {wholePersonLeadership.map(({ Icon, color, name, description }) => (
               <Grid
                 container

--- a/src/components/WholePersonLeadership/WholePersonLeadership.tsx
+++ b/src/components/WholePersonLeadership/WholePersonLeadership.tsx
@@ -3,6 +3,7 @@ import { Stack, Typography } from "@mui/material"
 import Grid from "@mui/material/Unstable_Grid2"
 import { Favorite, AutoAwesome, RocketLaunch } from "@mui/icons-material"
 
+import { FadeIn } from "@components/Layout"
 import VennDiagram from "./VennDiagram"
 
 type WholePersonLeadershipProps = {}
@@ -57,7 +58,9 @@ export default function WholePersonLeadership({}: WholePersonLeadershipProps) {
               display: { xs: "none", md: "block" },
             }}
           >
+            <FadeIn translateX={20}>
             Development through the Whole Person Leadership Model
+            </FadeIn>
           </Typography>
           <Typography
             variant="h3"
@@ -66,7 +69,11 @@ export default function WholePersonLeadership({}: WholePersonLeadershipProps) {
               display: { xs: "block", md: "none" },
             }}
           >
+            <FadeIn translateX={-20}>
+
+            
             Built by the current TA generation for the next generation
+            </FadeIn>
           </Typography>
           <Stack spacing={5} padding={1}>
             {wholePersonLeadership.map(({ Icon, color, name, description }) => (

--- a/src/components/WholePersonLeadership/WholePersonLeadership.tsx
+++ b/src/components/WholePersonLeadership/WholePersonLeadership.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { Stack, Typography } from "@mui/material"
 import Grid from "@mui/material/Unstable_Grid2"
 import { Favorite, AutoAwesome, RocketLaunch } from "@mui/icons-material"
+import { useTrail, useInView, animated } from "@react-spring/web"
 
 import { FadeIn } from "@components/Layout"
 import VennDiagram from "./VennDiagram"
@@ -31,7 +32,19 @@ const wholePersonLeadership = [
   },
 ]
 
+const AnimatedGrid = animated(Grid)
+
 export default function WholePersonLeadership({}: WholePersonLeadershipProps) {
+  const [ref, inView] = useInView({ once: true })
+  const [trails, __] = useTrail(
+    wholePersonLeadership.length,
+    () => ({
+      translateY: inView ? 0 : -20,
+      opacity: inView ? 1 : 0,
+    }),
+    [inView]
+  )
+
   return (
     <Grid container justifyContent="space-between">
       <Grid
@@ -59,7 +72,7 @@ export default function WholePersonLeadership({}: WholePersonLeadershipProps) {
             }}
           >
             <FadeIn translateX={20}>
-            Development through the Whole Person Leadership Model
+              Development through the Whole Person Leadership Model
             </FadeIn>
           </Typography>
           <Typography
@@ -70,33 +83,34 @@ export default function WholePersonLeadership({}: WholePersonLeadershipProps) {
             }}
           >
             <FadeIn translateX={-20}>
-
-            
-            Built by the current TA generation for the next generation
+              Built by the current TA generation for the next generation
             </FadeIn>
           </Typography>
-          <Stack spacing={5} padding={1}>
-            {wholePersonLeadership.map(({ Icon, color, name, description }) => (
-              <Grid
-                container
-                key={name}
-                columnSpacing={1}
-                rowSpacing={1}
-              >
-                <Grid>
-                  {/* @ts-ignore Tertiary added via module augmentation but doesn't show up here. */}
-                  <Icon color={color} fontSize="large" />
-                </Grid>
-                <Grid>
-                  <Typography variant="h4" color={`${color}.main`}>
-                    {name}
-                  </Typography>
-                </Grid>
-                <Grid xs={12}>
-                  <Typography variant="body1">{description}</Typography>
-                </Grid>
-              </Grid>
-            ))}
+          <Stack spacing={5} padding={1} ref={ref}>
+            {wholePersonLeadership.map(
+              ({ Icon, color, name, description }, index) => (
+                <AnimatedGrid
+                  container
+                  key={name}
+                  columnSpacing={1}
+                  rowSpacing={1}
+                  style={trails[index]}
+                >
+                  <Grid>
+                    {/* @ts-ignore Tertiary added via module augmentation but doesn't show up here. */}
+                    <Icon color={color} fontSize="large" />
+                  </Grid>
+                  <Grid>
+                    <Typography variant="h4" color={`${color}.main`}>
+                      {name}
+                    </Typography>
+                  </Grid>
+                  <Grid xs={12}>
+                    <Typography variant="body1">{description}</Typography>
+                  </Grid>
+                </AnimatedGrid>
+              )
+            )}
           </Stack>
         </Stack>
       </Grid>

--- a/src/components/YouTubeEmbed/YouTubeEmbed.tsx
+++ b/src/components/YouTubeEmbed/YouTubeEmbed.tsx
@@ -41,6 +41,7 @@ export default function YouTubeEmbed({
           autoplay: false
         }
       }}
+      loading="lazy"
       {...rest}
     />
   )

--- a/src/hooks/useMouseOver.ts
+++ b/src/hooks/useMouseOver.ts
@@ -1,0 +1,9 @@
+import React from "react"
+
+export default function useMouseOver(): [boolean, React.MouseEventHandler, React.MouseEventHandler] {
+  const [isMouseOver, setIsMouseOver] = React.useState(false)
+  const onMouseEnter: React.MouseEventHandler = () => setIsMouseOver(true)
+  const onMouseLeave: React.MouseEventHandler = () => setIsMouseOver(false)
+
+  return [isMouseOver, onMouseEnter, onMouseLeave]
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,7 +9,7 @@ import { AnimatedButton, SanityButton } from "@components/Button"
 import { PhotoGrid, Goals, Statistics } from "@components/IndexPage"
 import PortableText from "@components/PortableText"
 import { LinkWithIcon } from "@components/Link"
-import { Section } from "@components/Layout"
+import { FadeIn, Section } from "@components/Layout"
 import { QuoteCarousel } from "@components/Quotes"
 import { WholePersonLeadership } from "@components/WholePersonLeadership"
 import getPageTitle from "@utils/getPageTitle"
@@ -66,37 +66,45 @@ export default function IndexPage({ data }: PageProps<Queries.IndexPageQuery>) {
         >
           {/* Header */}
           <Grid xs={12} md={8}>
-            <Typography
-              variant="h1"
-              textAlign={{
-                xs: "center",
-                md: "left",
-              }}
-            >
-              {sanityHomePage.mainHeader}
-            </Typography>
-          </Grid>
-          {/* SubHeader */}
-          <Grid xs={12} md={4}>
-            <Stack spacing={2} alignItems={{ xs: "center", md: "self-start" }} sx={{paddingTop: 4}}>
+            <FadeIn translateX={-20}>
               <Typography
-                variant="h4"
+                variant="h1"
                 textAlign={{
                   xs: "center",
                   md: "left",
                 }}
               >
-                {sanityHomePage.subHeader}
+                {sanityHomePage.mainHeader}
               </Typography>
-
-              <SanityButton
-                boopProps={{ scale: 1.1 }}
-                content={sanityHomePage.subHeaderButton}
-                size="large"
+            </FadeIn>
+          </Grid>
+          {/* SubHeader */}
+          <Grid xs={12} md={4}>
+            <FadeIn translateX={20}>
+              <Stack
+                spacing={2}
+                alignItems={{ xs: "center", md: "self-start" }}
+                sx={{ paddingTop: 4 }}
               >
-                Register
-              </SanityButton>
-            </Stack>
+                <Typography
+                  variant="h4"
+                  textAlign={{
+                    xs: "center",
+                    md: "left",
+                  }}
+                >
+                  {sanityHomePage.subHeader}
+                </Typography>
+
+                <SanityButton
+                  boopProps={{ scale: 1.1 }}
+                  content={sanityHomePage.subHeaderButton}
+                  size="large"
+                >
+                  Register
+                </SanityButton>
+              </Stack>
+            </FadeIn>
           </Grid>
         </Grid>
       </Section>
@@ -119,6 +127,7 @@ export default function IndexPage({ data }: PageProps<Queries.IndexPageQuery>) {
           display: { xs: "none", md: "block" },
         }}
       >
+        <FadeIn translateY={-20}>
         <Stack spacing={4} alignItems="center">
           <Typography variant="h3" textAlign="center">
             {sanityHomePage.aboutHeader}
@@ -127,16 +136,25 @@ export default function IndexPage({ data }: PageProps<Queries.IndexPageQuery>) {
             <PortableText content={sanityHomePage._rawAboutBody} />
           </Container>
         </Stack>
+        </FadeIn>
       </Section>
 
       {/* What is LYF Camp? */}
       <Section backgroundColor="#F2F2F2">
-        <Grid container spacing={2} justifyContent="space-between" alignItems="center">
+        <Grid
+          container
+          spacing={2}
+          justifyContent="space-between"
+          alignItems="center"
+        >
           <Grid xs={12} lg={5}>
-            <Stack spacing={{xs: 4, lg: 8}}>
+            <Stack spacing={{ xs: 4, lg: 8 }}>
+              <FadeIn translateX={-20}>
               <Typography variant="h3" textAlign={{ xs: "center", md: "left" }}>
                 What is LYF Camp?
               </Typography>
+              </FadeIn>
+
               <PortableText
                 content={sanityHomePage._rawCampDescription}
                 spacing={2}
@@ -159,9 +177,11 @@ export default function IndexPage({ data }: PageProps<Queries.IndexPageQuery>) {
       {/* Goals of LYF Camp */}
       <Section>
         <Stack spacing={5}>
+          <FadeIn translateX={-20}>
           <Typography variant="h3" textAlign={{ xs: "center", md: "left" }}>
             Goals of LYF Camp
           </Typography>
+          </FadeIn>
           <Goals goals={sanityHomePage.goals} />
         </Stack>
       </Section>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -48,17 +48,6 @@ export const query = graphql`
   }
 `
 
-const Placeholder = () => (
-  <Box
-    sx={{
-      width: 1,
-      height: 1,
-      backgroundColor: "primary.main",
-      borderRadius: 5,
-    }}
-  />
-)
-
 export const Head = getPageTitle("Home")
 
 export default function IndexPage({ data }: PageProps<Queries.IndexPageQuery>) {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -73,6 +73,7 @@ export default function IndexPage({ data }: PageProps<Queries.IndexPageQuery>) {
           container
           justifyContent="space-between"
           flexWrap="wrap"
+          spacing={2}
         >
           {/* Header */}
           <Grid xs={12} md={8}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1197,6 +1197,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@fontsource/nunito@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@fontsource/nunito/-/nunito-5.0.0.tgz#780f1e9ed46719ea404434119d99491d31a721d2"
+  integrity sha512-lFzZwMES+Bv6SyaD8pfmkXYzEjFp1c59wuW3EuohIfpNvP9JHAGz9BJmGBXcjGVfo/bZRQs9Esk3W0dyFiAcDw==
+
 "@gatsbyjs/parcel-namer-relative-to-cwd@^2.10.0":
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/@gatsbyjs/parcel-namer-relative-to-cwd/-/parcel-namer-relative-to-cwd-2.10.0.tgz#3ad8ba465cde801282809559190893aab1f42e8e"
@@ -3238,14 +3243,6 @@ babel-preset-gatsby@^3.10.0:
     gatsby-core-utils "^4.10.0"
     gatsby-legacy-polyfills "^3.10.0"
 
-babel-runtime@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
-  integrity sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.11.0"
-
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -3877,11 +3874,6 @@ core-js-pure@^3.23.3:
   version "3.30.2"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.30.2.tgz#005a82551f4af3250dcfb46ed360fad32ced114e"
   integrity sha512-p/npFUJXXBkCCTIlEGBdghofn00jWG6ZOtdoIXSJmAu2QBvN0IqpZXWweOytcwE6cfx8ZvVUy1vw8zxhe4Y2vg==
-
-core-js@^2.4.0:
-  version "2.6.12"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
-  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-js@^3.30.1:
   version "3.30.2"
@@ -5580,14 +5572,6 @@ gatsby-plugin-utils@^4.10.0, gatsby-plugin-utils@^4.5.0:
     import-from "^4.0.0"
     joi "^17.9.2"
     mime "^3.0.0"
-
-gatsby-plugin-web-font-loader@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-web-font-loader/-/gatsby-plugin-web-font-loader-1.0.4.tgz#c50bdb0c1980110b3fd213a5be70feb2459514c3"
-  integrity sha512-3c39bX9CcsYJQFhhmTyjuMJSqpld2rX+HsTOxP9k1PKFR4Rvo3lpzBW4d1tVpmUesR8BNL6u9eHT7/XksS1iog==
-  dependencies:
-    babel-runtime "^6.26.0"
-    webfontloader "^1.6.28"
 
 gatsby-react-router-scroll@^6.10.0:
   version "6.10.0"
@@ -8614,11 +8598,6 @@ regenerate@^1.4.2:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
-regenerator-runtime@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
-  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
-
 regenerator-runtime@^0.13.11, regenerator-runtime@^0.13.7:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
@@ -9927,11 +9906,6 @@ weak-lru-cache@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz#fdbb6741f36bae9540d12f480ce8254060dccd19"
   integrity sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==
-
-webfontloader@^1.6.28:
-  version "1.6.28"
-  resolved "https://registry.yarnpkg.com/webfontloader/-/webfontloader-1.6.28.tgz#db786129253cb6e8eae54c2fb05f870af6675bae"
-  integrity sha512-Egb0oFEga6f+nSgasH3E0M405Pzn6y3/9tOVanv/DLfa1YBIgcv90L18YyWnvXkRbIM17v5Kv6IT2N6g1x5tvQ==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
Wahoo here we go! This one is a bit of a doozy but the biggest change is adding animations to many parts of the home page

- Add the `FadeIn` component which we can use to wrap any component and adding a fade in animation!
- Adds FadeIn for headers on the home page
- Adds a hover-over animation for the links in the fotter
- Makes the stat and venn diagram animations only animate once and once they're in view

This PR is also full of a bunch of bug fixes!
- Makes the scroll for quotes "auto" instead of "overflow" which hides the scroll bar unless we really need it
- Self-host the Nunito font which should fix the Flash of Unstyled Text (FOUT) 
- Fixes spacing of things 
- Removes unused imports