### PR TITLE
Add header image and scaffolding of timeline to history page

### DIFF
--- a/src/pages/about-us/history.tsx
+++ b/src/pages/about-us/history.tsx
@@ -1,15 +1,27 @@
 import * as React from "react"
 import { PageProps, graphql } from "gatsby"
-import { Stack, Typography } from "@mui/material"
+import { Stack, Typography, useTheme, Grid } from "@mui/material"
 
 import { Section } from "@components/Layout"
 import getPageTitle from "@utils/getPageTitle"
+import SanityImage from "@components/Image/SanityImage"
+import PortableText from "@components/PortableText"
 
 export const query = graphql`
   query HistoryPage {
     sanityHistoryPage {
       mainHeader
       subHeader
+      headerImage {
+        ...SanityImageAsset
+      }
+      timeline {
+        title
+        _rawDescription
+        image {
+          ...SanityImageAsset
+        }
+      }
     }
   }
 `
@@ -23,14 +35,64 @@ export default function HistoryPage({
   if (!sanityHistoryPage)
     throw `No Sanity document for the culture page was found.`
 
+  // for later:
+  // const theme = useTheme()
+  // const matches = useMediaQuery(theme.breakpoints.up("md"))
+
+  const { timeline } = sanityHistoryPage
+
+  const renderTimeline = () => {
+    return timeline ? (
+      <div>
+        <Stack>
+          {timeline.map((element, index) => {
+            const card = (
+              <Grid item xs={5}>
+                <Typography variant="h6">{element?.title}</Typography>
+                <SanityImage imageAsset={element?.image} />
+                <PortableText content={element?._rawDescription} />
+              </Grid>
+            )
+            const whitespace = <Grid item xs={5} />
+            return (
+              <Grid
+                container
+                direction="row"
+                alignItems="center"
+                justifyContent="center"
+                spacing={8}
+              >
+                {index % 2 == 1 && card}
+                {whitespace}
+                {index % 2 == 0 && card}
+              </Grid>
+            )
+          })}
+        </Stack>
+      </div>
+    ) : null
+  }
+
+  const { headerImage } = sanityHistoryPage
+
   return (
     <>
-      <Section>
-        <Stack>
-          <Typography variant="h3">{sanityHistoryPage?.mainHeader}</Typography>
-          <Typography variant="h6">{sanityHistoryPage?.subHeader}</Typography>
+      {/* Header Section */}
+      <Section backgroundColor="primary.main">
+        <Stack direction="row" spacing={4}>
+          <Stack spacing={4} justifyContent="center">
+            <Typography variant="h3" color="white">
+              {sanityHistoryPage?.mainHeader}
+            </Typography>
+            <Typography variant="h6" color="white">
+              {sanityHistoryPage?.subHeader}
+            </Typography>
+          </Stack>
+          <SanityImage imageAsset={headerImage} />
         </Stack>
       </Section>
+      {/* Timeline */}
+      <Section backgroundColor="white">{renderTimeline()}</Section>
     </>
   )
 }


### PR DESCRIPTION
Unfortunately did not have time to make the timeline look exactly like the designs - the black timeline bar isn't here and in general it's missing some styling polish. Also did not have time to adjust the logic for narrower screens, but the scaffolding is there and I thought I'd at least put up a PR with my progress. I don't think I'll be able to do too much more before STR :(

Looks like:
<img width="1492" alt="Screenshot 2023-05-31 at 10 47 13 PM" src="https://github.com/TACL-LYF/lyf-website/assets/8270089/06ba053a-1d1c-4b76-b95b-f6376a8afd53">
<img width="1276" alt="Screenshot 2023-05-31 at 11 09 40 PM" src="https://github.com/TACL-LYF/lyf-website/assets/8270089/03ff6fe3-6c24-4e53-8bbd-bbf0412fb6dc">



