### PR TITLE
Add mailchimp sign up form

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -32,6 +32,14 @@ const config: GatsbyConfig = {
         },
       },
     },
+    {
+      resolve: "gatsby-plugin-mailchimp",
+      options: {
+        endpoint:
+          "https://tacl.us7.list-manage.com/subscribe/post?u=723f6baf2c99017f0ff638067&amp;id=2bd94e4a2c&amp;f_id=00c2f8e4f0",
+        timeout: 5000,
+      },
+    },
     "gatsby-transformer-sharp",
   ],
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build": "gatsby build",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "clean-dev": "gatsby clean && gatsby develop"
   },
   "dependencies": {
     "@emotion/react": "^11.10.5",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "date-fns": "^2.29.3",
     "gatsby": "^5.0.0",
     "gatsby-plugin-image": "^3.3.2",
+    "gatsby-plugin-mailchimp": "^5.2.2",
     "gatsby-plugin-netlify": "^5.1.1",
     "gatsby-plugin-sanity-image": "^0.13.4",
     "gatsby-plugin-sharp": "^5.0.0",

--- a/src/components/Button/AnimatedButton.tsx
+++ b/src/components/Button/AnimatedButton.tsx
@@ -6,7 +6,7 @@ import useBoop, { BoopProps } from "@hooks/useBoop"
 
 const SpringAnimatedButton = animated(Button)
 
-type Props = ButtonProps & {
+export type AnimatedButtonProps = ButtonProps & {
   boopProps: BoopProps
 }
 
@@ -14,7 +14,7 @@ export default function AnimatedButton({
   boopProps,
   disabled,
   ...rest
-}: Props) {
+}: AnimatedButtonProps) {
   const [boopStyles, trigger] = useBoop({ ...boopProps, disabled })
 
   return (

--- a/src/components/Button/AnimatedButtonWithLoading.tsx
+++ b/src/components/Button/AnimatedButtonWithLoading.tsx
@@ -1,0 +1,32 @@
+import React from "react"
+
+import { CircularProgress } from "@mui/material"
+
+import AnimatedButton, { AnimatedButtonProps } from "./AnimatedButton"
+
+type AnimatedButtonWithLoadingProps = Omit<
+  AnimatedButtonProps,
+  "onClick" | "startIcon"
+> & {
+  asyncOnClick: () => Promise<void>
+}
+
+export default function AnimatedButtonWithLoading({
+  asyncOnClick,
+  ...rest
+}: AnimatedButtonWithLoadingProps) {
+  const [loading, setLoading] = React.useState(false)
+
+  const handleContinue = React.useCallback(() => {
+    setLoading(true)
+    asyncOnClick().finally(() => setLoading(false))
+  }, [asyncOnClick])
+
+  return (
+    <AnimatedButton
+      {...rest}
+      onClick={handleContinue}
+      startIcon={loading && <CircularProgress size={20} color="inherit" />}
+    />
+  )
+}

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -1,4 +1,5 @@
 export { default as AnimatedButton } from "./AnimatedButton"
+export { default as AnimatedButtonWithLoading } from "./AnimatedButtonWithLoading"
 export { default as AnimatedIconButton } from "./AnimatedIconButton"
 export { default as LinkButton } from "./LinkButton"
 export { default as SanityButton } from "./SanityButton"

--- a/src/components/Input/TextFieldWithFormValidation.tsx
+++ b/src/components/Input/TextFieldWithFormValidation.tsx
@@ -1,0 +1,24 @@
+import React from "react"
+import { TextField, TextFieldProps } from "@mui/material"
+
+type TextFieldWithFormValidationProps = TextFieldProps
+
+export default function TextFieldWithFormValidation({
+  required,
+  error,
+  value,
+  ...props
+}: TextFieldWithFormValidationProps) {
+  const [hasFocused, setHasFocused] = React.useState(false)
+  const formValidationError = required && hasFocused && !value
+
+  return (
+    <TextField
+      required={required}
+      error={error || formValidationError}
+      value={value ?? ""}
+      onBlur={() => setHasFocused(true)}
+      {...props}
+    />
+  )
+}

--- a/src/components/Input/index.ts
+++ b/src/components/Input/index.ts
@@ -1,0 +1,1 @@
+export { default as TextFieldWithFormValidation } from "./TextFieldWithFormValidation"

--- a/src/components/Mailchimp/MailchimpSignupForm.tsx
+++ b/src/components/Mailchimp/MailchimpSignupForm.tsx
@@ -1,0 +1,104 @@
+import React from "react"
+import { Typography, Grid2Props } from "@mui/material"
+import Grid from "@mui/material/Unstable_Grid2/Grid2"
+import addToMailchimp from "gatsby-plugin-mailchimp"
+
+import { TextFieldWithFormValidation } from "@components/Input"
+import { AnimatedButtonWithLoading } from "@components/Button"
+
+type MailchimpSignupFormProps = Omit<Grid2Props, "children" | "container">
+
+export default function MailchimpSignupForm({
+  ...props
+}: MailchimpSignupFormProps) {
+  const [email, setEmail] = React.useState("")
+  const [firstName, setFirstName] = React.useState("")
+  const [lastName, setLastName] = React.useState("")
+  const [error, setError] = React.useState<string | null>(null)
+  const [msg, setMsg] = React.useState<string | null>(null)
+  const invalidState = firstName === "" || lastName === "" || email === ""
+
+  const handleSubmit = React.useCallback(async () => {
+    setError(null)
+    setMsg(null)
+
+    const { result, msg } = await addToMailchimp(email, {
+      FNAME: firstName,
+      LNAME: lastName,
+    })
+    if (result === "error") {
+      setError(msg)
+    } else {
+      setMsg(msg)
+    }
+
+  }, [email, firstName, lastName, setError, setMsg])
+
+  return (
+    <Grid container spacing={2} justifyContent="center" {...props}>
+      <Grid xs={12}>
+        <Typography variant="h3" align="center">
+          Join our mailing list!
+        </Typography>
+      </Grid>
+
+      <Grid xs={12}>
+        <TextFieldWithFormValidation
+          id="email"
+          label="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          fullWidth
+          required
+        />
+      </Grid>
+      <Grid xs={6}>
+        <TextFieldWithFormValidation
+          id="first-name"
+          label="First Name"
+          value={firstName}
+          onChange={(e) => setFirstName(e.target.value)}
+          fullWidth
+          required
+        />
+      </Grid>
+      <Grid xs={6}>
+        <TextFieldWithFormValidation
+          id="last-name"
+          label="Last Name"
+          value={lastName}
+          onChange={(e) => setLastName(e.target.value)}
+          fullWidth
+          required
+        />
+      </Grid>
+      <Grid xs={12}>
+        <AnimatedButtonWithLoading
+          asyncOnClick={handleSubmit}
+          variant="contained"
+          fullWidth
+          boopProps={{
+            scale: 1.05,
+          }}
+          disabled={invalidState}
+        >
+          Subscribe to mailing list
+        </AnimatedButtonWithLoading>
+      </Grid>
+      {error && (
+        <Grid>
+          <Typography color="error" variant="body1" align="center">
+            {error}
+          </Typography>
+        </Grid>
+      )}
+      {msg && (
+        <Grid>
+          <Typography color="tertiary.dark" variant="body1" align="center">
+            {msg}
+          </Typography>
+        </Grid>
+      )}
+    </Grid>
+  )
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,6 +14,7 @@ import { QuoteCarousel } from "@components/Quotes"
 import { WholePersonLeadership } from "@components/WholePersonLeadership"
 import getPageTitle from "@utils/getPageTitle"
 import CampOverlayVideo from "@components/YouTubeEmbed/CampOverlayVideo"
+import MailchimpSignupForm from "@components/Mailchimp/MailchimpSignupForm"
 
 export const query = graphql`
   query IndexPage {
@@ -198,9 +199,12 @@ export default function IndexPage({ data }: PageProps<Queries.IndexPageQuery>) {
         <WholePersonLeadership />
       </Section>
 
-      {/* Quotes */}
+      {/* Quotes and Mailchimp */}
       <Section>
         <QuoteCarousel quotes={sanityHomePage.quotes} color="tertiary" />
+        <MailchimpSignupForm sx={{
+          paddingTop: 4
+        }}/>
       </Section>
 
       {/* CTAs */}

--- a/src/types/gatsby-plugin-mailchimp.ts
+++ b/src/types/gatsby-plugin-mailchimp.ts
@@ -1,0 +1,7 @@
+declare module "gatsby-plugin-mailchimp" {
+  export default function addToMailchimp(
+      email: string,
+      fields?: any,
+      endpointOverride?: any
+  ): { result: string; msg: string }
+}

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,5 +1,0 @@
-# Redirects from what the browser requests to what we serve
-# I added "/l/" in front of the link name to denote that it's an external link and not a page on our site
-# This may be a hassle to type out, but I believe it's a good separation of pages
-
-/2024FamilySurvey            https://docs.google.com/forms/d/e/1FAIpQLSdXEbJcOK8V4jv6aBa9HtUFQXbS3tCbOA_tfJmJ4wQRW4Ft-g/viewform?usp=sf_link

--- a/yarn.lock
+++ b/yarn.lock
@@ -4122,7 +4122,7 @@ debounce@^1.2.1:
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
   integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
 
-debug@2, debug@2.6.9, debug@^2.6.0, debug@^2.6.8:
+debug@2, debug@2.6.9, debug@^2.1.3, debug@^2.6.0, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -4417,6 +4417,11 @@ electron-to-chromium@^1.4.284:
   version "1.4.402"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.402.tgz#9aa7bbb63081513127870af6d22f829344c5ba57"
   integrity sha512-gWYvJSkohOiBE6ecVYXkrDgNaUjo47QEKK0kQzmWyhkH+yoYiG44bwuicTGNSIQRG3WDMsWVZJLRnJnLNkbWvA==
+
+email-validator@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/email-validator/-/email-validator-2.0.4.tgz#b8dfaa5d0dae28f1b03c95881d904d4e40bfe7ed"
+  integrity sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -5538,6 +5543,14 @@ gatsby-plugin-image@^3.3.2:
     gatsby-plugin-utils "^4.10.0"
     objectFitPolyfill "^2.3.5"
     prop-types "^15.8.1"
+
+gatsby-plugin-mailchimp@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-mailchimp/-/gatsby-plugin-mailchimp-5.2.2.tgz#bed94cb70b9d91267329a5e6a0220e821d8ff6e8"
+  integrity sha512-O9JizVPJAe5YT1QAHZNRh1xUVdPnfayfIRhsBULiK2629TQRvEzzQxTDbt/WZU02cVm8415Fx2CneaxYKLt0ag==
+  dependencies:
+    email-validator "^2.0.4"
+    jsonp "^0.2.1"
 
 gatsby-plugin-netlify@^5.1.1:
   version "5.1.1"
@@ -6858,6 +6871,13 @@ jsonfile@^6.0.1:
     universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+jsonp@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/jsonp/-/jsonp-0.2.1.tgz#a65b4fa0f10bda719a05441ea7b94c55f3e15bae"
+  integrity sha512-pfog5gdDxPdV4eP7Kg87M8/bHgshlZ5pybl+yKxAnCZ5O7lCIn7Ixydj03wOlnDQesky2BPyA91SQ+5Y/mNwzw==
+  dependencies:
+    debug "^2.1.3"
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.3.3:
   version "3.3.3"


### PR DESCRIPTION
# Context
We want an easy way for people to sign up for out general mailing list! Doing so via the main website can help us get more people on there

# This diff
Adds [gatsby-plugin-mailchimp](https://www.gatsbyjs.com/plugins/gatsby-plugin-mailchimp/?=mailchimp) which makes it super easy to add mailchimp embedded forms with our own custom formatting 

Adds a new component MailchimpSignUpForm which has all the required fields

Copies over some code from the lyf-registration repo so we can use it here as well
- [AnimatedButtonWithLoading](https://github.com/TACL-LYF/lyf-registration/blob/main/website/src/components/Button/AnimatedButtonWithLoading.tsx)
-  [TextFieldWithFormValidation](https://github.com/TACL-LYF/lyf-registration/blob/main/website/src/components/Inputs/TextFieldWithFormValidation.tsx)


https://github.com/user-attachments/assets/93f8a9a8-476d-4841-b187-711828d8d66a

