### PR TITLE
Add registration policy page to website

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -50,6 +50,10 @@ const PAGES: Page[] = [
         to: "/camp/faqs",
         text: "FAQs",
       },
+      {
+        to: "/camp/registration-policy",
+        text: "Registration Policy",
+      },
     ],
   },
   {

--- a/src/pages/camp/registration-policy.tsx
+++ b/src/pages/camp/registration-policy.tsx
@@ -1,0 +1,38 @@
+import React from "react"
+import { graphql, PageProps } from "gatsby"
+import getPageTitle from "@utils/getPageTitle"
+import { Section } from "@components/Layout"
+import { Typography } from "@mui/material"
+import PortableText from "@components/PortableText"
+
+export const query = graphql`
+  query RegistrationPolicyPage {
+    sanityRegistrationPolicyPage {
+      mainHeader
+      _rawMainContent
+    }
+  }
+`
+
+export const Head = getPageTitle("Registration Policy")
+
+export default function RegistrationPolicyPage({
+  data,
+}: PageProps<Queries.RegistrationPolicyPageQuery>) {
+  const { sanityRegistrationPolicyPage } = data
+  if (!sanityRegistrationPolicyPage)
+    throw `No Sanity document for the registration policy page was found.`
+
+  const { mainHeader, _rawMainContent } = sanityRegistrationPolicyPage
+
+  return (
+    <>
+      <Section backgroundColor="secondary.light">
+        <Typography variant="h3">{mainHeader}</Typography>
+      </Section>
+      <Section maxWidth="lg">
+        <PortableText content={_rawMainContent} gap={1} />
+      </Section>
+    </>
+  )
+}


### PR DESCRIPTION
# Context
We want to host the registration policy on the website rather than linking to a Google Doc every year.

# This PR
Uses the schema created in [our CMS](https://github.com/TACL-LYF/lyf-website-cms/pull/32) and creates a dedicated page from it. Since all we have is a header and a body, this page is also relatively simpler 